### PR TITLE
fix: 优化缓存管理器和流水线管理器逻辑，更新配置示例及版本号

### DIFF
--- a/packages/compiler-core/CHANGELOG.md
+++ b/packages/compiler-core/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.8.1] - 2026-05-14
+
+### Fixed
+
+- **修复部分缓存数据丢失的问题**：改进增量编译的缓存持久化逻辑，确保数据完整保存
+
+---
+
+[1.8.1]: https://github.com/vureact-js/core/compare/v1.8.0...v1.8.1
+
+---
+
 ## [1.8.0] - 2026-05-05
 
 ### Changed
@@ -619,7 +631,8 @@ When releasing a new version:
 ---
 
 ```text
-[Unreleased]: https://github.com/vureact-js/core/compare/v1.8.0...HEAD
+[Unreleased]: https://github.com/vureact-js/core/compare/v1.8.1...HEAD
+[1.8.1]: https://github.com/vureact-js/core/compare/v1.8.0...v1.8.1
 [1.8.0]: https://github.com/vureact-js/core/compare/v1.7.0...v1.8.0
 [1.7.0]: https://github.com/vureact-js/core/compare/v1.6.2...v1.7.0
 [1.6.2]: https://github.com/vureact-js/core/compare/v1.6.1...v1.6.2

--- a/packages/compiler-core/examples/crm-ops-portal/vureact.config.ts
+++ b/packages/compiler-core/examples/crm-ops-portal/vureact.config.ts
@@ -1,4 +1,4 @@
-import { defineConfig } from '../../src';
+import { defineConfig } from '../../src/config';
 
 export default defineConfig({
   input: 'src',

--- a/packages/compiler-core/examples/customer-support-hub/vureact.config.ts
+++ b/packages/compiler-core/examples/customer-support-hub/vureact.config.ts
@@ -1,4 +1,4 @@
-﻿import { defineConfig } from '../../src';
+import { defineConfig } from '../../src/config';
 
 export default defineConfig({
   exclude: ['src/main.ts'],

--- a/packages/compiler-core/package.json
+++ b/packages/compiler-core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@vureact/compiler-core",
-  "version": "1.8.0",
-  "description": "⚡ Write in Vue 3, compile to React 18+ code.",
+  "version": "1.8.1",
+  "description": "🌀 Write in Vue 3, compile to React 18+ output.",
   "author": "Ruihong Zhong (Ryan John)",
   "license": "MIT",
   "type": "module",
@@ -49,7 +49,7 @@
     "progressive-migration",
     "automated-refactoring"
   ],
-  "homepage": "https://vureact.top",
+  "homepage": "https://github.com/vureact-js/core#readme",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/vureact-js/core.git",

--- a/packages/compiler-core/src/compiler/shared/file-compiler/cache-manager.ts
+++ b/packages/compiler-core/src/compiler/shared/file-compiler/cache-manager.ts
@@ -69,9 +69,7 @@ export class CacheManager {
 
       if (!updates?.length) continue;
 
-      const activeFiles = new Set(updates.map((u) => u.unit.file));
-
-      const entries = (this.cachedData![key] || []).filter((c) => activeFiles.has(c.file));
+      const entries = [...(this.cachedData![key] || [])];
 
       updates.forEach(({ unit, meta }) => {
         const idx = entries.findIndex((c) => c.file === unit.file);
@@ -169,9 +167,7 @@ export class CacheManager {
     }
 
     // 合并待更新数据到 cachedData
-    const activeFiles = new Set(updates.map((u) => u.unit.file));
-    let entries = (this.cachedData || this.getEmptyList())[key] || [];
-    entries = entries.filter((c: any) => activeFiles.has(c.file));
+    const entries = [...(((this.cachedData || this.getEmptyList())[key] || []) as any[])];
 
     updates.forEach(({ unit, meta }) => {
       const idx = entries.findIndex((c: any) => c.file === unit.file);

--- a/packages/compiler-core/src/compiler/shared/file-compiler/pipeline-manager.ts
+++ b/packages/compiler-core/src/compiler/shared/file-compiler/pipeline-manager.ts
@@ -73,5 +73,6 @@ export class PipelineManager {
    */
   resetSkippedCount(): void {
     this.skippedCount = 0;
+    this.fileProcessor.resetSkippedCount();
   }
 }

--- a/packages/compiler-core/src/config.ts
+++ b/packages/compiler-core/src/config.ts
@@ -1,0 +1,3 @@
+export { defineConfig } from './compiler/shared/define-config';
+export type { UserConfigFnObject } from './compiler/shared/define-config';
+export type { CompilerOptions as UserConfig } from './compiler/shared/types';


### PR DESCRIPTION
问题：当重复增量编译时，即使没有任何文件修改且复用了缓存，但终端依旧会输出错误统计，任意的 Proceed: xx 。

修复方案：改了缓存刷新逻辑，让增量构建只覆盖本轮更新项，不再把“未变更文件的缓存记录”误删掉，位置在 `cache-manager.ts (line 68)` 和  `cache-manager.ts (line 170)`。同时把跳过计数的重置补完整了，避免统计串到下一轮，位置在 `pipeline-manager.ts (line 74)`。