### PR TITLE
fix: 优化文件编译器和文件监听器逻辑，清理冗余代码

### DIFF
--- a/packages/compiler-core/CHANGELOG.md
+++ b/packages/compiler-core/CHANGELOG.md
@@ -5,11 +5,24 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.8.3] - 2026-05-15
+
+### Fixed
+
+- **修复 watch 模式改回初始内容后 React 端未触发热更新的问题**：优化缓存校验，文件恢复初始状态时能正确识别变化并同步产物
+- **移除组件名文件名回退的多余警告**：未显式声明名称时按文件名推导组件名属于正常兜底，不再输出 warning 日志
+
+---
+
+[1.8.3]: https://github.com/vureact-js/core/compare/v1.8.1...v1.8.3
+
+---
+
 ## [1.8.1] - 2026-05-14
 
 ### Fixed
 
-- **修复部分缓存数据丢失的问题**：改进增量编译的缓存持久化逻辑，确保数据完整保存
+- **修复增量编译时部分缓存数据丢失的问题**：改进增量编译的缓存持久化逻辑，确保数据完整保存，避免增量编译功能失效
 
 ---
 
@@ -631,7 +644,8 @@ When releasing a new version:
 ---
 
 ```text
-[Unreleased]: https://github.com/vureact-js/core/compare/v1.8.1...HEAD
+[Unreleased]: https://github.com/vureact-js/core/compare/v1.8.3...HEAD
+[1.8.3]: https://github.com/vureact-js/core/compare/v1.8.1...v1.8.3
 [1.8.1]: https://github.com/vureact-js/core/compare/v1.8.0...v1.8.1
 [1.8.0]: https://github.com/vureact-js/core/compare/v1.7.0...v1.8.0
 [1.7.0]: https://github.com/vureact-js/core/compare/v1.6.2...v1.7.0

--- a/packages/compiler-core/package.json
+++ b/packages/compiler-core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@vureact/compiler-core",
-  "version": "1.8.1",
-  "description": "🌀 Write in Vue 3, compile to React 18+ output.",
+  "version": "1.8.3",
+  "description": "🌀 Write in Vue 3, compile to React 18+.",
   "author": "Ruihong Zhong (Ryan John)",
   "license": "MIT",
   "type": "module",
@@ -63,7 +63,8 @@
   },
   "scripts": {
     "build": "tsup",
-    "test": "tsx watch"
+    "test": "tsx watch",
+    "prepublishOnly": "npm run build"
   },
   "peerDependencies": {
     "prettier": "^3.0.0"

--- a/packages/compiler-core/src/cli/action/file-watcher.ts
+++ b/packages/compiler-core/src/cli/action/file-watcher.ts
@@ -16,7 +16,7 @@ export function setupWatcher(compiler: VuReact, config: CompilerOptions) {
   const watcher = chokidar.watch(cmpHelper.getInputPath(), {
     ignored: cmpHelper.getExcludes(),
     persistent: true,
-    ignoreInitial: true, // 初始扫描已由 compiler.execute 完成
+    ignoreInitial: true,
   });
 
   watcher.on('all', async (event, filePath) => {
@@ -44,6 +44,7 @@ export function setupWatcher(compiler: VuReact, config: CompilerOptions) {
 
   const onRecompile = async (event: 'add' | 'change', filePath: string) => {
     const ext = path.extname(filePath);
+    const relativePath = normalizePath(cmpHelper.relativePath(filePath));
 
     if (ext in processors) {
       spinner.start('Recompiling...');
@@ -53,20 +54,23 @@ export function setupWatcher(compiler: VuReact, config: CompilerOptions) {
       const unit = await fn(filePath);
 
       cmpHelper.printCoreLogs();
-      cmpHelper.printCompileInfo(filePath, calcElapsedTime(startTime));
 
-      // 调用编译器 onChange 方法
+      // fix: 只当编译产出才打印 Compiled，缓存命中会明确打印 Cached。
       if (unit) {
+        cmpHelper.print(
+          kleur.green('compiled'),
+          kleur.dim(relativePath),
+          kleur.gray(`(${calcElapsedTime(startTime)})`),
+        );
         await config.onChange?.(event, unit);
+      } else {
+        cmpHelper.print(kleur.gray('cached'), kleur.dim(relativePath));
       }
     } else {
       spinner.start('Updating assets...');
       await compiler.processAsset(filePath);
 
-      cmpHelper.print(
-        kleur.blue('Copied Asset'),
-        kleur.dim(normalizePath(cmpHelper.relativePath(filePath))),
-      );
+      cmpHelper.print(kleur.blue('Copied Asset'), kleur.dim(relativePath));
     }
 
     spinner.stop();
@@ -74,19 +78,16 @@ export function setupWatcher(compiler: VuReact, config: CompilerOptions) {
 
   const onRemoveFile = async (type: 'unlink' | 'unlinkDir', filePath: string) => {
     const ext = path.extname(filePath);
+    const relativePath = normalizePath(cmpHelper.relativePath(filePath));
 
     const scriptExtRegex = /\.(js|ts)$/i;
     const styleExtRegex = /\.(css|less|sass|scss)$/i;
 
-    const removeFile = async (type: CacheKey) => {
-      await compiler.removeOutputPath(filePath, type);
-      cmpHelper.print(
-        kleur.yellow('Removed'),
-        kleur.dim(normalizePath(cmpHelper.relativePath(filePath))),
-      );
+    const removeFile = async (cacheKey: CacheKey) => {
+      await compiler.removeOutputPath(filePath, cacheKey);
+      cmpHelper.print(kleur.yellow('Removed'), kleur.dim(relativePath));
     };
 
-    // 单个文件删除
     if (type === 'unlink') {
       if (ext === '.vue') {
         await removeFile(CacheKey.SFC);
@@ -107,8 +108,6 @@ export function setupWatcher(compiler: VuReact, config: CompilerOptions) {
       return;
     }
 
-    // 文件夹删除：尝试同时清理 Vue 产物和 资产产物
-    // 这里不需要判断 isVue，因为文件夹本身不带后缀
     if (type === 'unlinkDir') {
       await removeFile(CacheKey.SFC);
       await removeFile(CacheKey.SCRIPT);

--- a/packages/compiler-core/src/compiler/shared/file-compiler/__tests__/watch-mode-regression.test.ts
+++ b/packages/compiler-core/src/compiler/shared/file-compiler/__tests__/watch-mode-regression.test.ts
@@ -1,0 +1,109 @@
+import assert from 'node:assert/strict';
+import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import test from 'node:test';
+import { logger } from '@shared/logger';
+import { FileCompiler } from '..';
+
+async function createTempProject(source: string) {
+  const root = await mkdtemp(path.join(os.tmpdir(), 'vureact-watch-'));
+  const srcDir = path.join(root, 'src');
+  const vueFile = path.join(srcDir, 'App.vue');
+
+  await mkdir(srcDir, { recursive: true });
+
+  await writeFile(
+    path.join(root, 'package.json'),
+    JSON.stringify({
+      name: 'watch-regression-fixture',
+      private: true,
+      type: 'module',
+    }),
+    'utf-8',
+  );
+  await writeFile(vueFile, source, 'utf-8');
+
+  return { root, vueFile };
+}
+
+function createCompiler(root: string) {
+  return new FileCompiler({
+    root,
+    watch: true,
+    output: {
+      bootstrapVite: false,
+    },
+  });
+}
+
+test('watch mode recompiles when a Vue file is restored to its initial content', async () => {
+  const initialSource = `<template><div>{{ label }}</div></template>
+<script setup lang="ts">
+const label = 'initial'
+</script>
+`;
+  const changedSource = `<template><div>{{ label }}</div></template>
+<script setup lang="ts">
+const label = 'changed'
+</script>
+`;
+
+  const { root, vueFile } = await createTempProject(initialSource);
+
+  try {
+    const buildCompiler = createCompiler(root);
+    await buildCompiler.execute();
+
+    const watchCompiler = createCompiler(root);
+    await writeFile(vueFile, changedSource, 'utf-8');
+
+    const changedUnit = await watchCompiler.processSFC(vueFile);
+    assert.ok(changedUnit?.output, 'changed source should compile in watch mode');
+
+    const outputFile = changedUnit!.output!.jsx.file;
+    const changedOutput = await readFile(outputFile, 'utf-8');
+    assert.match(changedOutput, /changed/);
+
+    await writeFile(vueFile, initialSource, 'utf-8');
+
+    const restoredUnit = await watchCompiler.processSFC(vueFile);
+    assert.ok(restoredUnit?.output, 'restoring initial source should still recompile in watch mode');
+
+    const restoredOutput = await readFile(outputFile, 'utf-8');
+    assert.match(restoredOutput, /initial/);
+    assert.doesNotMatch(restoredOutput, /changed/);
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test('component name fallback does not emit unnamed-component warnings', () => {
+  logger.clear();
+
+  const compiler = new FileCompiler({
+    output: {
+      bootstrapVite: false,
+    },
+  });
+
+  const source = `<template><div>Hello</div></template>
+<script setup lang="ts">
+const count = 1
+</script>
+`;
+
+  const result = compiler.compile(source, path.join('fixtures', 'account-overview.vue'));
+  const warnings = logger
+    .getLogs()
+    .filter((log) => log.level === 'warning')
+    .map((log) => log.message);
+
+  assert.match(result.code, /const AccountOverview = memo/);
+  assert.equal(
+    warnings.some((message) => message.includes('Unnamed component detected')),
+    false,
+  );
+
+  logger.clear();
+});

--- a/packages/compiler-core/src/compiler/shared/file-compiler/file-processor.ts
+++ b/packages/compiler-core/src/compiler/shared/file-compiler/file-processor.ts
@@ -150,6 +150,11 @@ export class FileProcessor {
       }
 
       await this.cacheManager.updateCacheIncrementally(processed, key);
+
+      // fix: watch 场景直接调用 processFile 时，当前文件缓存需要立即同步到磁盘
+      if (this.fileCompiler.getIsCache() && !existingCache) {
+        await this.cacheManager.flushCache(key);
+      }
     }
 
     return processed;

--- a/packages/compiler-core/src/compiler/shared/file-compiler/index.ts
+++ b/packages/compiler-core/src/compiler/shared/file-compiler/index.ts
@@ -67,7 +67,7 @@ export class FileCompiler extends BaseCompiler {
     let startTime = 0;
 
     try {
-      this.updateSpinner('Initializing Vite React env...');
+      this.updateSpinner('Initializing environment...');
       await viteBootstrapper.bootstrapIfNeeded();
 
       // feature：https://github.com/vureact-js/core/issues/28

--- a/packages/compiler-core/src/compiler/shared/file-compiler/vite-bootstrapper.ts
+++ b/packages/compiler-core/src/compiler/shared/file-compiler/vite-bootstrapper.ts
@@ -115,7 +115,7 @@ export class ViteBootstrapper {
     // 写入新数据到 vite 项目的 package.json
     await this.fileCompiler.writeFileWithDir(outputPkgPath, JSON.stringify(newPkg, null, 2));
 
-    this.spinner.succeed('Initialized Vite React environment');
+    this.spinner.succeed('Vite React environment initialized');
 
     return true;
   }

--- a/packages/compiler-core/src/compiler/shared/helper.ts
+++ b/packages/compiler-core/src/compiler/shared/helper.ts
@@ -338,14 +338,6 @@ export class Helper {
     logger.clear();
   }
 
-  printCompileInfo(file: string, duration: string) {
-    this.print(
-      kleur.green('Compiled'),
-      kleur.dim(normalizePath(this.relativePath(file))),
-      kleur.gray(`(${duration})`),
-    );
-  }
-
   print(...message: any[]) {
     if (this.compilerOpts.watch) {
       const time = new Date().toLocaleTimeString();

--- a/packages/compiler-core/src/core/codegen/component/script/syntax-processor/process/build-component-function.ts
+++ b/packages/compiler-core/src/core/codegen/component/script/syntax-processor/process/build-component-function.ts
@@ -2,7 +2,6 @@ import { ParseResult } from '@babel/parser';
 import * as t from '@babel/types';
 import { ICompilationContext } from '@compiler/context/types';
 import { REACT_API_MAP } from '@consts/react-api-map';
-import { logger } from '@src/shared/logger';
 import { ScriptBlockIR } from '@transform/sfc/script';
 import { camelCase } from '@utils/camelCase';
 import { capitalize } from '@utils/capitalize';
@@ -93,9 +92,6 @@ function resolveComponentName(ctx: ICompilationContext): t.Identifier {
     // 没有设置组件名则回退到文件名/随机名
     const defaultName = basename(filename).split('.')[0] || `FC${genHashByXXH(filename)}`;
     name = capitalize(camelCase(defaultName));
-    logger.warn(`Unnamed component detected. Using file name: <${name}>`, {
-      file: filename,
-    });
   }
 
   scriptData.declaredOptions.name = name;

--- a/packages/runtime-core/package.json
+++ b/packages/runtime-core/package.json
@@ -78,6 +78,7 @@
   },
   "scripts": {
     "build": "rimraf dist && rollup -c --bundleConfigAsCjs",
+    "prepublishOnly": "npm run build",
     "test": "jest",
     "test:watch": "jest --watch",
     "test:coverage": "jest --coverage"


### PR DESCRIPTION
## Bug 描述：vureact watch 模式相关问题


### 问题 1：修改恢复至初始内容后，React 端无法热更新

在该示例项目中，同时运行 `npx vureact watch` 服务和 React 应用的 Vite dev 服务时：

- **正常行为**：当修改 `App.vue` 的内容后，两个服务均能正常更新，Vue 至 React 的同步生效。
- **异常行为**：当将 `App.vue` 的修改全部恢复至最初编译时的初始内容时，虽然 `vureact watch` 服务终端显示已重新编译，但 React Vite dev 服务未触发热更新，且对应的 `App.tsx` 内容也未同步变更，仍停留在上一次修改状态。
- **测试结论**：经过多次测试，发现只要 Vue 端文件内容与最初编译后的状态不一致，任何修改都能正常编译同步至 React 端；但一旦将内容完全恢复为初始状态，尽管终端显示编译完成，实际文件并未更新。

### 问题 2：每次编译时出现警告

在上述问题 1 所描述的场景下，每次修改内容后重新编译时，`vureact watch` 服务都会在终端输出以下警告：

```
[vureact] WARNING: Unnamed component detected. Using file name: <App> 
at src/App.vue
```