### PR TITLE
Update English and Chinese changelogs for compiler-core

### DIFF
--- a/packages/compiler-core/CHANGELOG-zh-CN.md
+++ b/packages/compiler-core/CHANGELOG-zh-CN.md
@@ -5,6 +5,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.8.5] - 2026-05-27
+
+### Fixed
+
+- 修复 `provide()` 内部使用如 `computed()` 等可映射的 API 时，会漏转为 React 产物 [#46](https://github.com/vureact-js/core/issues/46)
+- 修复无模板组件中使用 provide 后，生成的 React jsx 丢失 `<Provider>` 组件 [#51](https://github.com/vureact-js/core/issues/51)
+
+---
+
+[1.8.5]: https://github.com/vureact-js/core/compare/v1.8.4...v1.8.5
+
+---
+
 ## [1.8.4] - 2026-05-25
 
 ### Fixed
@@ -661,7 +674,9 @@ When releasing a new version:
 ---
 
 ```text
-[Unreleased]: https://github.com/vureact-js/core/compare/v1.8.3...HEAD
+[Unreleased]: https://github.com/vureact-js/core/compare/v1.8.5...HEAD
+[1.8.5]: https://github.com/vureact-js/core/compare/v1.8.4...v1.8.5
+[1.8.4]: https://github.com/vureact-js/core/compare/v1.8.3...v1.8.4
 [1.8.3]: https://github.com/vureact-js/core/compare/v1.8.1...v1.8.3
 [1.8.1]: https://github.com/vureact-js/core/compare/v1.8.0...v1.8.1
 [1.8.0]: https://github.com/vureact-js/core/compare/v1.7.0...v1.8.0

--- a/packages/compiler-core/CHANGELOG.md
+++ b/packages/compiler-core/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.8.5] - 2026-05-27
+
+### Fixed
+
+- Fixed `provide()` internally using mappable APIs like `computed()` not being converted to React output [#46](https://github.com/vureact-js/core/issues/46)
+- Fixed missing `<Provider>` component in generated React JSX when using provide in a template-less component [#51](https://github.com/vureact-js/core/issues/51)
+
+---
+
+[1.8.5]: https://github.com/vureact-js/core/compare/v1.8.4...v1.8.5
+
+---
+
 ## [1.8.4] - 2026-05-25
 
 ### Fixed
@@ -661,7 +674,8 @@ When releasing a new version:
 ---
 
 ```text
-[Unreleased]: https://github.com/vureact-js/core/compare/v1.8.4...HEAD
+[Unreleased]: https://github.com/vureact-js/core/compare/v1.8.5...HEAD
+[1.8.5]: https://github.com/vureact-js/core/compare/v1.8.4...v1.8.5
 [1.8.4]: https://github.com/vureact-js/core/compare/v1.8.3...v1.8.4
 [1.8.3]: https://github.com/vureact-js/core/compare/v1.8.1...v1.8.3
 [1.8.1]: https://github.com/vureact-js/core/compare/v1.8.0...v1.8.1


### PR DESCRIPTION
- 修复 `provide()` 内部使用如 `computed()` 等可映射的 API 时，会漏转为 React 产物 [#46](https://github.com/vureact-js/core/issues/46)
- 修复无模板组件中使用 provide 后，生成的 React jsx 丢失 `<Provider>` 组件 [#51](https://github.com/vureact-js/core/issues/51)