### PR TITLE
test(compiler-core): 新增编译器和核心功能测试用例

### DIFF
--- a/packages/compiler-core/src/__tests__/compiler/helper-io.test.ts
+++ b/packages/compiler-core/src/__tests__/compiler/helper-io.test.ts
@@ -1,0 +1,67 @@
+import { fileLock } from '@compiler/shared/file-lock-manager';
+import { Helper } from '@compiler/shared/helper';
+import { logger } from '@shared/logger';
+import fs from 'fs';
+import path from 'path';
+
+describe('Helper I/O (partial)', () => {
+  const root = process.cwd();
+  const opts: any = {
+    root,
+    input: 'src',
+    output: { outDir: 'dist', workspace: '.vureact-test-io' },
+  };
+  const helper = new Helper(opts);
+
+  beforeEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  test('writeFileWithDir uses fileLock when lock option is true', async () => {
+    const spy = jest.spyOn(fileLock, 'updateFile').mockResolvedValue('ok' as any);
+
+    const tmp = path.resolve(root, '.tmp_helper_lock.json');
+    await helper.writeFileWithDir(tmp, '{"a":1}', { lock: true } as any);
+
+    expect(spy).toHaveBeenCalled();
+  });
+
+  test('rmFile removes existing file', async () => {
+    const tmpDir = path.resolve(root, '.tmp_helper_io');
+    const tmpFile = path.join(tmpDir, 'tfile.txt');
+    await fs.promises.mkdir(tmpDir, { recursive: true });
+    await fs.promises.writeFile(tmpFile, 'hello', 'utf-8');
+
+    await helper.rmFile(tmpFile);
+
+    expect(fs.existsSync(tmpFile)).toBe(false);
+    // cleanup
+    try {
+      await fs.promises.rm(tmpDir, { recursive: true, force: true });
+    } catch {}
+  });
+
+  test('getFileMeta returns size and mtime', async () => {
+    const tmpDir = path.resolve(root, '.tmp_helper_io2');
+    const tmpFile = path.join(tmpDir, 'tfile2.txt');
+    await fs.promises.mkdir(tmpDir, { recursive: true });
+    await fs.promises.writeFile(tmpFile, 'hello2', 'utf-8');
+
+    const meta = await helper.getFileMeta(tmpFile);
+    expect(meta.fileSize).toBeGreaterThan(0);
+    expect(typeof meta.mtime).toBe('number');
+
+    await fs.promises.rm(tmpDir, { recursive: true, force: true });
+  });
+
+  test('printCoreLogs uses logger when logs exist', () => {
+    jest.spyOn(logger, 'getLogs').mockReturnValue([1] as any);
+    const printSpy = jest.spyOn(logger, 'printAll').mockImplementation(() => ({}) as any);
+    const clearSpy = jest.spyOn(logger, 'clear').mockImplementation(() => ({}) as any);
+
+    helper.printCoreLogs();
+
+    expect(printSpy).toHaveBeenCalled();
+    expect(clearSpy).toHaveBeenCalled();
+  });
+});

--- a/packages/compiler-core/src/__tests__/compiler/helper.test.ts
+++ b/packages/compiler-core/src/__tests__/compiler/helper.test.ts
@@ -1,0 +1,90 @@
+import { Helper } from '@compiler/shared/helper';
+import path from 'path';
+
+jest.mock('@plugins/prettier', () => ({
+  formatWithPrettier: jest.fn(async () => 'prettier'),
+  simpleFormat: jest.fn(() => 'simple'),
+}));
+
+describe('Helper (partial)', () => {
+  const root = process.cwd();
+  const opts: any = {
+    root,
+    input: 'src',
+    output: { outDir: 'dist', workspace: '.vureact-test', ignoreAssets: ['foo.txt'] },
+  };
+  const helper = new Helper(opts);
+
+  test('basic path helpers', () => {
+    expect(helper.getProjectRoot()).toBe(root);
+    expect(helper.getInputPath()).toBe(path.resolve(root, 'src'));
+    expect(helper.getOutDirName()).toBe('dist');
+    expect(helper.getWorkspaceDir()).toBe(path.resolve(root, '.vureact-test'));
+    expect(helper.getRootPkgPath()).toBe(path.join(root, 'package.json'));
+    expect(helper.getOutputPkgPath()).toBe(path.join(helper.getOuputPath(), 'package.json'));
+  });
+
+  test('ignore assets and cache flag', () => {
+    const ignores = helper.getIgnoreAssets();
+    expect(ignores.has('foo.txt')).toBe(true);
+    expect(helper.getIsCache()).toBe(true); // default true when not provided
+  });
+
+  test('relative and replace vue ext', () => {
+    const filePath = path.resolve(root, 'src', 'comp.vue');
+    const replaced = helper.replaceVueFileExt(filePath, '.jsx');
+    expect(replaced.endsWith('.jsx')).toBe(true);
+    const rel = helper.relativePath(filePath);
+    expect(typeof rel).toBe('string');
+  });
+
+  test('genHash and compareFileMeta', async () => {
+    const h = helper.genHash('abc');
+    expect(typeof h).toBe('string');
+
+    const a = { fileSize: 10, mtime: 100 };
+    const b = { fileSize: 10, mtime: 100 };
+    expect(helper.compareFileMeta(a as any, b as any)).toBe(true);
+  });
+
+  test('updateCache updates existing and pushes new', () => {
+    const cache: any = { target: [{ file: 'a', data: 1 }] };
+    helper.updateCache('a', { file: 'a', data: 2 }, cache);
+    expect(cache.target.find((c: any) => c.file === 'a').data).toBe(2);
+
+    helper.updateCache('b', { file: 'b', data: 3 }, cache);
+    expect(cache.target.find((c: any) => c.file === 'b').data).toBe(3);
+  });
+
+  test('resolveRelativePath removes extension and normalizes', () => {
+    const from = path.resolve(root, 'src');
+    const to = path.resolve(root, 'src', 'lib', 'mod.js');
+    const rel = helper.resolveRelativePath(from, to);
+    expect(rel.startsWith('./')).toBe(true);
+    expect(rel.includes('mod')).toBe(true);
+  });
+
+  test('checkCacheStatus branches', async () => {
+    const current = { fileSize: 1, mtime: 2 } as any;
+
+    // no cache
+    const r1 = await helper.checkCacheStatus(current, undefined, async () => 'x');
+    expect(r1.shouldCompile).toBe(true);
+
+    // same meta
+    const cached = { fileSize: 1, mtime: 2 } as any;
+    const r2 = await helper.checkCacheStatus(current, cached, async () => 'x');
+    expect(r2.shouldCompile).toBe(false);
+
+    // changed meta but same hash
+    const cached2: any = { fileSize: 0, mtime: 0, hash: helper.genHash('hello') };
+    const r3 = await helper.checkCacheStatus(current, cached2, async () => 'hello');
+    expect(r3.shouldCompile).toBe(false);
+
+    // changed meta and different hash
+    const cached3: any = { fileSize: 0, mtime: 0, hash: 'different' };
+    const r4 = await helper.checkCacheStatus(current, cached3, async () => 'hello');
+    expect(r4.shouldCompile).toBe(true);
+    expect(typeof r4.hash).toBe('string');
+  });
+});

--- a/packages/compiler-core/src/__tests__/compiler/shared/file-lock-manager.test.ts
+++ b/packages/compiler-core/src/__tests__/compiler/shared/file-lock-manager.test.ts
@@ -1,0 +1,46 @@
+import fs from 'fs';
+import { fileLock } from '../../../compiler/shared/file-lock-manager';
+
+describe('file-lock-manager', () => {
+  const tmpFile = 'tmp-lock-test.json';
+
+  afterEach(async () => {
+    try {
+      await fs.promises.unlink(tmpFile);
+    } catch {}
+  });
+
+  test('updateFile creates file and writes JSON', async () => {
+    const res = await fileLock.updateFile(tmpFile, (cur) => ({ count: (cur?.count || 0) + 1 }));
+    expect(res).toEqual({ count: 1 });
+
+    const content = await fs.promises.readFile(tmpFile, 'utf-8');
+    expect(JSON.parse(content)).toEqual({ count: 1 });
+  });
+
+  test('tryLock returns release function when lock acquired and null otherwise', async () => {
+    const release = await fileLock.tryLock(tmpFile);
+    if (release) {
+      // another tryLock should fail immediately
+      const second = await fileLock.tryLock(tmpFile);
+      expect(second).toBeNull();
+      await release();
+    } else {
+      // in some environments proper-lockfile may not allow locking same path; accept null
+      expect(release).toBeNull();
+    }
+  });
+
+  test('isLocked reflects lock state', async () => {
+    const rel = await fileLock.tryLock(tmpFile);
+    const locked = await fileLock.isLocked(tmpFile);
+    if (rel) {
+      expect(locked).toBe(true);
+      await rel();
+      const unlocked = await fileLock.isLocked(tmpFile);
+      expect(unlocked).toBe(false);
+    } else {
+      expect(locked).toBe(false);
+    }
+  });
+});

--- a/packages/compiler-core/src/__tests__/core/babel-utils.test.ts
+++ b/packages/compiler-core/src/__tests__/core/babel-utils.test.ts
@@ -1,0 +1,247 @@
+import * as t from '@babel/types';
+import {
+  cleanNodeComments,
+  cleanNodeLoc,
+  expressionToTSType,
+  forkNode,
+  isCalleeNamed,
+  replaceCallName,
+  replaceIdName,
+  replaceNode,
+} from '@core/transform/sfc/script/shared/babel-utils';
+
+describe('core/babel-utils', () => {
+  test('expressionToTSType handles primitives and arrays', () => {
+    const s = expressionToTSType(t.stringLiteral('a'));
+    expect(s.type).toBe('TSStringKeyword');
+
+    const n = expressionToTSType(t.numericLiteral(1));
+    expect(n.type).toBe('TSNumberKeyword');
+
+    const b = expressionToTSType(t.booleanLiteral(true));
+    expect(b.type).toBe('TSBooleanKeyword');
+
+    const arr = expressionToTSType(t.arrayExpression([t.numericLiteral(1)]));
+    expect(arr.type).toBe('TSArrayType');
+  });
+
+  test('findRootIdentifier / findRootVariablePath / getVariableDeclaratorPath', () => {
+    const mem = t.memberExpression(t.identifier('a'), t.identifier('b'));
+    const fakeBindingPath: any = { isVariableDeclarator: () => true };
+    const fakeScope: any = { getBinding: (name: string) => ({ path: fakeBindingPath }) };
+
+    const fakePath: any = { node: mem, scope: fakeScope };
+
+    // findRootIdentifier
+    const root = (
+      require('@core/transform/sfc/script/shared/babel-utils') as any
+    ).findRootIdentifier(mem);
+    expect(root && root.name).toBe('a');
+
+    // findRootVariablePath should return the fake binding path
+    const rootVar = (
+      require('@core/transform/sfc/script/shared/babel-utils') as any
+    ).findRootVariablePath(fakePath);
+    expect(rootVar).toBe(fakeBindingPath);
+  });
+
+  test('checkIsCallExpInAnyCallback detects callback argument', () => {
+    const fnNode: any = t.arrowFunctionExpression([], t.blockStatement([]));
+    const callNode: any = t.callExpression(t.identifier('c'), [fnNode]);
+
+    const funcPath: any = {
+      node: fnNode,
+      isFunctionDeclaration: () => false,
+      isFunctionExpression: () => false,
+      isArrowFunctionExpression: () => true,
+      parentPath: null as any,
+    };
+
+    const callPath: any = { node: callNode, isCallExpression: () => true, arguments: [fnNode] };
+
+    funcPath.parentPath = callPath;
+
+    const startPath: any = { parentPath: funcPath };
+
+    const res = (
+      require('@core/transform/sfc/script/shared/babel-utils') as any
+    ).checkIsCallExpInAnyCallback(startPath);
+    expect(res).toBe(true);
+  });
+
+  test('isVariableDeclTopLevel works for program and parent program', () => {
+    const varDecPath: any = { parentPath: { isProgram: () => true } };
+    const res1 = (
+      require('@core/transform/sfc/script/shared/babel-utils') as any
+    ).isVariableDeclTopLevel(varDecPath);
+    expect(res1).toBe(true);
+
+    const nestedVarDecPath: any = {
+      parentPath: { isProgram: () => false, parentPath: { isProgram: () => true } },
+    };
+    const res2 = (
+      require('@core/transform/sfc/script/shared/babel-utils') as any
+    ).isVariableDeclTopLevel(nestedVarDecPath);
+    expect(res2).toBe(true);
+  });
+
+  test('isIdentifierAccess / isRealVariableAccess / isPropertyName', () => {
+    const id = t.identifier('X');
+    const pathNoBinding: any = {
+      node: id,
+      scope: { getBinding: () => undefined },
+      parentPath: null,
+    };
+    const access = (
+      require('@core/transform/sfc/script/shared/babel-utils') as any
+    ).isIdentifierAccess(pathNoBinding);
+    expect(access).toBe(true);
+
+    // binding that points to same identifier => declaration
+    const binding = { identifier: id };
+    const pathWithBinding: any = {
+      node: id,
+      scope: { getBinding: () => binding },
+      parentPath: null,
+    };
+    const access2 = (
+      require('@core/transform/sfc/script/shared/babel-utils') as any
+    ).isIdentifierAccess(pathWithBinding);
+    expect(access2).toBe(false);
+
+    // property name
+    const propPath: any = {
+      parentPath: {
+        isObjectProperty: () => true,
+        isClassProperty: () => false,
+        isMemberExpression: () => false,
+        node: { key: id },
+      },
+    };
+    const isProp = (require('@core/transform/sfc/script/shared/babel-utils') as any).isPropertyName(
+      { parentPath: propPath.parentPath, node: id } as any,
+    );
+    expect(isProp).toBe(true);
+
+    const realAccess = (
+      require('@core/transform/sfc/script/shared/babel-utils') as any
+    ).isRealVariableAccess(pathNoBinding);
+    expect(realAccess).toBe(true);
+  });
+
+  test('resolveObjectToTSType and stringValueToTSType', () => {
+    const ctx: any = { filename: '', scriptData: { lang: 'ts' } };
+    const obj = { title: "'name'", count: '1', text: 'greetingMessage', fn: '() => 1' };
+
+    const tlit = (
+      require('@core/transform/sfc/script/shared/babel-utils') as any
+    ).resolveObjectToTSType(ctx, obj);
+
+    const memberNames = (tlit.members || []).map((m: any) =>
+      m.key.name ? m.key.name : m.key.value,
+    );
+    expect(memberNames).toEqual(expect.arrayContaining(['title', 'count', 'text', 'fn']));
+  });
+
+  test('isSimpleLiteral returns expected booleans', () => {
+    const isSimple = (
+      require('@core/transform/sfc/script/shared/babel-utils') as any
+    ).isSimpleLiteral(t.stringLiteral('s'));
+    expect(isSimple).toBe(true);
+
+    const isNot = (require('@core/transform/sfc/script/shared/babel-utils') as any).isSimpleLiteral(
+      null,
+    );
+    expect(isNot).toBe(false);
+  });
+
+  test('expressionToTSType handles object expressions and functions', () => {
+    const obj = t.objectExpression([
+      t.objectProperty(t.identifier('title'), t.stringLiteral('x')),
+      t.objectProperty(t.identifier('count'), t.numericLiteral(2)),
+    ]);
+
+    const res = expressionToTSType(obj);
+    expect(res.type).toBe('TSTypeLiteral');
+    // two members created
+    // @ts-ignore
+    expect((res.members || []).length).toBeGreaterThanOrEqual(2);
+
+    const fnExpr = t.arrowFunctionExpression(
+      [t.identifier('a')],
+      t.blockStatement([t.returnStatement(t.numericLiteral(3))]),
+    );
+
+    const fnType = expressionToTSType(fnExpr);
+    expect(fnType.type).toBe('TSFunctionType');
+  });
+
+  test('isCalleeNamed / replaceCallName / replaceIdName', () => {
+    const call = t.callExpression(t.identifier('oldName'), []);
+    expect(isCalleeNamed(call, 'oldName')).toBe(true);
+
+    replaceCallName(call, 'newName');
+    // @ts-ignore
+    expect((call.callee as any).name).toBe('newName');
+
+    const id = t.identifier('i');
+    // @ts-ignore
+    id.loc = { identifierName: 'i' };
+    replaceIdName(id, 'j');
+    expect(id.name).toBe('j');
+    // @ts-ignore
+    expect(id.loc && (id.loc as any).identifierName).toBe('j');
+  });
+
+  test('forkNode / cleanNodeLoc / cleanNodeComments / replaceNode', () => {
+    const node = t.identifier('a');
+    // @ts-ignore
+    node.start = 1;
+    // @ts-ignore
+    node.end = 2;
+    // @ts-ignore
+    node.loc = { foo: true };
+    // @ts-ignore
+    node.leadingComments = [{ type: 'CommentLine', value: 'l' }];
+    // @ts-ignore
+    node.innerComments = [{ type: 'CommentBlock', value: 'i' }];
+
+    const forked = forkNode(node);
+    // forked should inherit comments
+    // @ts-ignore
+    expect(forked.leadingComments).toBeDefined();
+    // original node loc should be cleared
+    // @ts-ignore
+    expect(node.start).toBeNull();
+
+    // cleanNodeLoc / cleanNodeComments
+    const n2 = t.identifier('b');
+    // @ts-ignore
+    n2.start = 10;
+    cleanNodeLoc(n2);
+    // @ts-ignore
+    expect(n2.start).toBeNull();
+
+    // comments
+    // @ts-ignore
+    n2.leadingComments = [{ type: 'CommentLine', value: 'x' }];
+    cleanNodeComments(n2);
+    // @ts-ignore
+    expect(n2.leadingComments).toBeNull();
+
+    // replaceNode
+    const target = t.identifier('t');
+    const source = t.identifier('s');
+    // @ts-ignore
+    source.start = 5;
+    // @ts-ignore
+    source.leadingComments = [{ type: 'CommentLine', value: 'c' }];
+
+    const fakePath: any = { replaceWith: jest.fn() };
+    replaceNode(fakePath as any, target as any, source as any);
+    expect(fakePath.replaceWith).toHaveBeenCalledWith(target);
+    // target should get loc and comments set
+    // @ts-ignore
+    expect(target.start).toBe(5);
+  });
+});

--- a/packages/compiler-core/src/__tests__/core/clone-callable-params.test.ts
+++ b/packages/compiler-core/src/__tests__/core/clone-callable-params.test.ts
@@ -1,0 +1,53 @@
+import * as t from '@babel/types';
+import { cloneCallableParams } from '@core/transform/sfc/script/syntax-processor/preprocess/resolve-props-interface/shared';
+
+describe('cloneCallableParams', () => {
+  test('clones identifier param preserving optional and typeAnnotation', () => {
+    const id = t.identifier('p');
+    id.optional = true as any;
+    id.typeAnnotation = t.tsTypeAnnotation(t.tsNumberKeyword());
+
+    const res = cloneCallableParams([id as any]);
+    expect(res.length).toBe(1);
+    const out = res[0] as any;
+    expect(t.isIdentifier(out)).toBe(true);
+    expect(out.name).toBe('p');
+    expect(out.optional).toBe(true);
+    expect(t.isTSNumberKeyword(out.typeAnnotation.typeAnnotation)).toBe(true);
+  });
+
+  test('clones rest element with identifier argument and produces array type fallback', () => {
+    const rest = t.restElement(t.identifier('xs'));
+    // no typeAnnotation on rest or arg
+
+    const res = cloneCallableParams([rest as any]);
+    expect(res.length).toBe(1);
+    const out = res[0] as any;
+    expect(t.isRestElement(out)).toBe(true);
+    expect(t.isIdentifier(out.argument)).toBe(true);
+    expect(out.argument.name).toBe('xs');
+    expect(t.isTSTypeAnnotation(out.typeAnnotation)).toBe(true);
+    const inner = out.typeAnnotation.typeAnnotation;
+    expect(t.isTSArrayType(inner)).toBe(true);
+  });
+
+  test('clones rest element with non-identifier argument names it args0', () => {
+    const rest = t.restElement(t.arrayPattern([t.identifier('a')]));
+    const res = cloneCallableParams([rest as any]);
+    const out = res[0] as any;
+    expect(t.isRestElement(out)).toBe(true);
+    expect(t.isIdentifier(out.argument)).toBe(true);
+    expect(out.argument.name).toBe('args0');
+  });
+
+  test('pattern fallback becomes argN identifier with any type', () => {
+    const pat = t.objectPattern([t.objectProperty(t.identifier('x'), t.identifier('y'))]);
+    const res = cloneCallableParams([pat as any]);
+    expect(res.length).toBe(1);
+    const out = res[0] as any;
+    expect(t.isIdentifier(out)).toBe(true);
+    expect(out.name).toBe('arg0');
+    expect(t.isTSTypeAnnotation(out.typeAnnotation)).toBe(true);
+    expect(t.isTSAnyKeyword(out.typeAnnotation.typeAnnotation)).toBe(true);
+  });
+});

--- a/packages/compiler-core/src/__tests__/core/prop-ir-utils.test.ts
+++ b/packages/compiler-core/src/__tests__/core/prop-ir-utils.test.ts
@@ -1,0 +1,94 @@
+import * as propIR from '@core/transform/sfc/template/shared/prop-ir-utils';
+import { logger } from '@shared/logger';
+import * as strTypes from '@shared/string-code-types';
+import { PropTypes } from '@transform/sfc/template/shared/types';
+
+describe('prop-ir-utils', () => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+  });
+
+  test('createPropsIR returns expected structure and uses rawName', () => {
+    const res = propIR.createPropsIR('data-id', 'data-id', '42');
+    expect(res.rawName).toBe('data-id');
+    expect(res.name).toBe('data-id');
+    expect(res.value.content).toBe('42');
+  });
+
+  test('normalizePropName handles special cases and camel-casing', () => {
+    expect(propIR.normalizePropName('raw', 'v-html')).toBe('dangerouslySetInnerHTML');
+    expect(propIR.normalizePropName('raw', 'class')).toBe('className');
+    expect(propIR.normalizePropName('v-for', 'for')).toBe('for');
+    expect(propIR.normalizePropName('raw', 'data-id')).toBe('data-id');
+    expect(propIR.normalizePropName(':raw', 'my-prop')).toBe('myProp');
+  });
+
+  test('normalizeValue wraps non-literals when static', () => {
+    jest.spyOn(strTypes.strCodeTypes, 'isStringLiteral').mockReturnValue(false);
+    expect(propIR.normalizeValue('abc', true)).toBe("'abc'");
+
+    jest.spyOn(strTypes.strCodeTypes, 'isStringLiteral').mockReturnValue(true);
+    expect(propIR.normalizeValue("'abc'", false)).toBe("'abc'");
+  });
+
+  test('isV* helpers and attr/style checks', () => {
+    expect(propIR.isVOn('@click')).toBe(true);
+    expect(propIR.isVOn('v-on:click')).toBe(true);
+    expect(propIR.isVSlot('#slot')).toBe(true);
+    expect(propIR.isVBind(':style')).toBe(true);
+    expect(propIR.isVModel('v-model')).toBe(true);
+    expect(propIR.isClassAttr('class')).toBe(true);
+    expect(propIR.isStyleAttr('style')).toBe(true);
+    expect(propIR.isVConditional('v-if')).toBe(true);
+  });
+
+  test('findSameProp finds matching prop by name', () => {
+    const source = [
+      { isStatic: true, type: PropTypes.ATTRIBUTE, name: 'id' },
+      { isStatic: true, type: PropTypes.ATTRIBUTE, name: 'other' },
+    ];
+    const target = { isStatic: true, type: PropTypes.ATTRIBUTE, name: 'id' };
+
+    const found = propIR.findSameProp(source as any, target as any);
+    expect(found).toBe(source[0]);
+  });
+
+  test('wrapSingleQuotes respects condition and string-literal detection', () => {
+    jest.spyOn(strTypes.strCodeTypes, 'isStringLiteral').mockReturnValue(false);
+    expect(propIR.wrapSingleQuotes('x', true)).toBe("'x'");
+
+    jest.spyOn(strTypes.strCodeTypes, 'isStringLiteral').mockReturnValue(true);
+    expect(propIR.wrapSingleQuotes('y')).toBe("'y'");
+  });
+
+  test('checkPropIsDynamicKey logs warnings for keyless v-bind and dynamic names', () => {
+    const spy = jest.spyOn(logger, 'warn').mockImplementation(() => {});
+    const ctx: any = { source: 's', filename: 'f' };
+
+    // keyless v-bind
+    const node1: any = { rawName: 'v-bind' };
+    propIR.checkPropIsDynamicKey(ctx, node1);
+    expect(spy).toHaveBeenCalled();
+
+    spy.mockClear();
+
+    // dynamic slot name
+    const node2: any = { rawName: 'v-slot', arg: { isStatic: false, loc: {} } };
+    propIR.checkPropIsDynamicKey(ctx, node2);
+    expect(spy).toHaveBeenCalled();
+  });
+
+  test('addKeyToNodeIR pushes a key prop', () => {
+    const node: any = { props: [] };
+    const ctx: any = {
+      scriptData: { lang: 'js' },
+      templateData: { reactiveBindings: [] },
+      imports: new Map(),
+    };
+
+    propIR.addKeyToNodeIR(node, null as any, ctx);
+
+    expect(node.props.length).toBe(1);
+    expect(node.props[0].name).toBe('key');
+  });
+});

--- a/packages/compiler-core/src/__tests__/core/prop-merge-utils.test.ts
+++ b/packages/compiler-core/src/__tests__/core/prop-merge-utils.test.ts
@@ -1,0 +1,56 @@
+import { mergePropsIR } from '@core/transform/sfc/template/shared/prop-merge-utils';
+import { PropTypes } from '@core/transform/sfc/template/shared/types';
+
+describe('prop-merge-utils', () => {
+  test('mergePropsIR copies non-class/style attrs', () => {
+    const oldAttr: any = { a: 1 };
+    const newAttr: any = { b: 2 };
+    mergePropsIR({} as any, oldAttr, newAttr);
+    expect((oldAttr as any).b).toBe(2);
+  });
+
+  test('mergeClassProps merges string literals', () => {
+    const ctx: any = {
+      filename: 'x',
+      scriptData: { lang: 'js' },
+      templateData: { reactiveBindings: [] },
+    };
+    const oldAttr: any = {
+      type: PropTypes.ATTRIBUTE,
+      rawName: 'class',
+      value: { content: "'old'", isStringLiteral: true, babelExp: { ast: null } },
+      isStatic: true,
+      babelExp: {},
+    };
+
+    const newAttr: any = {
+      type: PropTypes.ATTRIBUTE,
+      rawName: 'class',
+      value: { content: "'new'", isStringLiteral: true, babelExp: { ast: null } },
+      isStatic: true,
+      babelExp: {},
+    };
+
+    mergePropsIR(ctx, oldAttr, newAttr);
+    expect(oldAttr.value.content.includes('old')).toBe(true);
+    expect(oldAttr.value.babelExp.ast).toBeDefined();
+  });
+
+  test('mergeStyleProps merges simple styles into Object.assign call', () => {
+    const oldAttr: any = {
+      rawName: 'style',
+      value: { content: '{a:1}', isStringLiteral: false, merge: undefined },
+    };
+
+    const newAttr: any = {
+      rawName: 'style',
+      value: { content: '{b:2}', isStringLiteral: false },
+    };
+
+    mergePropsIR({} as any, oldAttr, newAttr);
+    const ok =
+      Array.isArray(oldAttr.value.merge) ||
+      (oldAttr.value.content && oldAttr.value.content.includes('Object.assign'));
+    expect(ok).toBe(true);
+  });
+});

--- a/packages/compiler-core/src/__tests__/core/resolve-attribute-prop.test.ts
+++ b/packages/compiler-core/src/__tests__/core/resolve-attribute-prop.test.ts
@@ -1,0 +1,43 @@
+import { resolveAttributeProp } from '@core/transform/sfc/template/syntax-processor/process/props/resolve-attribute-prop';
+import * as dynMod from '@core/transform/sfc/template/syntax-processor/process/props/resolve-dynamic-attribute-prop';
+import * as isMod from '@core/transform/sfc/template/syntax-processor/process/props/resolve-is-prop';
+import * as refMod from '@core/transform/sfc/template/syntax-processor/process/props/resolve-ref-prop';
+
+describe('resolveAttributeProp', () => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+  });
+
+  test('handles is attribute by delegating to resolveStaticIsProp', () => {
+    const spy = jest.spyOn(isMod, 'resolveStaticIsProp').mockImplementation(() => {});
+
+    const attr: any = { name: 'is', value: { content: 'comp' } };
+
+    resolveAttributeProp(attr as any, {} as any, {} as any, {} as any);
+
+    expect(spy).toHaveBeenCalledTimes(1);
+  });
+
+  test('handles ref attribute by delegating to resolveRefProp', () => {
+    const spy = jest.spyOn(refMod, 'resolveRefProp').mockImplementation(() => {});
+
+    const attr: any = { name: 'ref', value: { content: '' } };
+
+    resolveAttributeProp(attr as any, {} as any, {} as any, {} as any);
+
+    expect(spy).toHaveBeenCalledTimes(1);
+  });
+
+  test('creates attr IR and calls resolvePropertyIR for generic attribute', () => {
+    const spy = jest.spyOn(dynMod, 'resolvePropertyIR').mockImplementation(() => {});
+
+    const attr: any = { name: 'data-id', value: { content: '42' } };
+
+    resolveAttributeProp(attr as any, {} as any, {} as any, {} as any);
+
+    expect(spy).toHaveBeenCalledTimes(1);
+    const firstArg = spy.mock.calls[0][0];
+    expect(firstArg).toHaveProperty('rawName', 'data-id');
+    expect(firstArg.value.isStringLiteral).toBe(true);
+  });
+});

--- a/packages/compiler-core/src/__tests__/core/resolve-directive-prop.test.ts
+++ b/packages/compiler-core/src/__tests__/core/resolve-directive-prop.test.ts
@@ -1,0 +1,82 @@
+import * as proc from '@core/transform/sfc/template/syntax-processor/process/props';
+import { resolveDirectiveProp } from '@core/transform/sfc/template/syntax-processor/process/props/resolve-directive-prop';
+import * as warnUtils from '@transform/sfc/template/shared/warning-utils';
+
+describe('resolveDirectiveProp', () => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+  });
+
+  test('warns on unsupported directive', () => {
+    const spy = jest.spyOn(warnUtils, 'warnUnsupportedDirective').mockImplementation(() => {});
+
+    const directive: any = { name: 'unknown', rawName: 'v-unknown', loc: {} };
+    const res = resolveDirectiveProp(
+      directive as any,
+      {} as any,
+      { source: '' } as any,
+      {} as any,
+      {} as any,
+      [] as any,
+    );
+
+    expect(spy).toHaveBeenCalledWith(expect.anything(), directive.loc, directive.rawName);
+    expect(res).toBeUndefined();
+  });
+
+  test('v-html calls resolveVHtml and returns true', () => {
+    const spy = jest.spyOn(proc, 'resolveVHtml').mockImplementation(() => {});
+
+    const directive: any = { name: 'html', rawName: 'v-html', loc: {} };
+
+    const res = resolveDirectiveProp(
+      directive as any,
+      {} as any,
+      {} as any,
+      {} as any,
+      {} as any,
+      [] as any,
+    );
+
+    expect(spy).toHaveBeenCalledTimes(1);
+    expect(res).toBe(true);
+  });
+
+  test('v-text calls resolveVText', () => {
+    const spy = jest.spyOn(proc, 'resolveVText').mockImplementation(() => {});
+
+    const directive: any = { name: 'text', rawName: 'v-text', loc: {} };
+
+    resolveDirectiveProp(directive as any, {} as any, {} as any, {} as any, {} as any, [] as any);
+
+    expect(spy).toHaveBeenCalledTimes(1);
+  });
+
+  test('v-for calls resolveVFor', () => {
+    const spy = jest.spyOn(proc, 'resolveVFor').mockImplementation(() => {});
+
+    const directive: any = { name: 'for', rawName: 'v-for', loc: {} };
+
+    resolveDirectiveProp(directive as any, {} as any, {} as any, {} as any, {} as any, [] as any);
+
+    expect(spy).toHaveBeenCalledTimes(1);
+  });
+
+  test('v-slot with RouterLink calls resolveRouterLinkVSlotProp', () => {
+    const spy = jest.spyOn(proc, 'resolveRouterLinkVSlotProp').mockImplementation(() => {});
+
+    const directive: any = { name: 'slot', rawName: 'v-slot', loc: {} };
+    const nodeIR: any = { tag: 'RouterLink' };
+
+    resolveDirectiveProp(
+      directive as any,
+      {} as any,
+      {} as any,
+      { tag: 'div' } as any,
+      nodeIR as any,
+      [] as any,
+    );
+
+    expect(spy).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/compiler-core/src/__tests__/core/resolve-emits.test.ts
+++ b/packages/compiler-core/src/__tests__/core/resolve-emits.test.ts
@@ -1,0 +1,556 @@
+import * as t from '@babel/types';
+import {
+  resolveDefineEmitsIface,
+  resolveEmitsTopLevelTypes,
+} from '@core/transform/sfc/script/syntax-processor/preprocess/resolve-props-interface/resolve-emits';
+
+describe('resolve-emits (runtime inference)', () => {
+  test('infer from array runtime argument', () => {
+    const ctx: any = { scriptData: { propsTSIface: { emitTypes: [] } } };
+
+    const call = t.callExpression(t.identifier('defineEmits'), [
+      t.arrayExpression([t.stringLiteral('change')]),
+    ]);
+    const path: any = { node: call };
+
+    resolveDefineEmitsIface(path, ctx);
+
+    expect(ctx.scriptData.propsTSIface.emitTypes.length).toBeGreaterThan(0);
+    const lit = ctx.scriptData.propsTSIface.emitTypes[0];
+    expect(t.isTSTypeLiteral(lit)).toBe(true);
+
+    const member = (lit as any).members[0];
+    const key = member.key;
+    if (t.isIdentifier(key)) {
+      expect(key.name).toBe('onChange');
+    } else {
+      expect(key.value).toBe('onChange');
+    }
+  });
+
+  test('infer from object runtime argument with tuple param', () => {
+    const ctx: any = { scriptData: { propsTSIface: { emitTypes: [] } } };
+
+    const propValue = t.arrayExpression([t.identifier('value')]);
+    const prop = t.objectProperty(t.identifier('update'), propValue);
+    const call = t.callExpression(t.identifier('defineEmits'), [t.objectExpression([prop])]);
+    const path: any = { node: call };
+
+    resolveDefineEmitsIface(path, ctx);
+
+    expect(ctx.scriptData.propsTSIface.emitTypes.length).toBeGreaterThan(0);
+    const lit = ctx.scriptData.propsTSIface.emitTypes[0];
+
+    const found = (lit as any).members.find(
+      (m: any) => (t.isIdentifier(m.key) ? m.key.name : m.key.value) === 'onUpdate',
+    );
+    expect(found).toBeDefined();
+  });
+});
+
+describe('resolve-emits (explicit types and top-level)', () => {
+  test('explicit function type parameter with union event names', () => {
+    const ctx: any = { scriptData: { propsTSIface: { emitTypes: [] } } };
+
+    const eventId = t.identifier('e');
+    eventId.typeAnnotation = t.tsTypeAnnotation(
+      t.tsUnionType([
+        t.tsLiteralType(t.stringLiteral('foo')),
+        t.tsLiteralType(t.stringLiteral('bar')),
+      ]),
+    );
+
+    const fnType = t.tsFunctionType(null, [eventId], t.tsTypeAnnotation(t.tsVoidKeyword()));
+
+    const call = t.callExpression(t.identifier('defineEmits'), []);
+    // attach explicit TS type parameter
+    (call as any).typeParameters = t.tsTypeParameterInstantiation([fnType as any]);
+
+    const path: any = { node: call };
+
+    resolveDefineEmitsIface(path, ctx);
+
+    expect(ctx.scriptData.propsTSIface.emitTypes.length).toBeGreaterThan(0);
+    const lit = ctx.scriptData.propsTSIface.emitTypes[0] as any;
+    const names = lit.members.map((m: any) => (t.isIdentifier(m.key) ? m.key.name : m.key.value));
+    expect(names).toEqual(expect.arrayContaining(['onFoo', 'onBar']));
+  });
+
+  test('explicit literal property signature transforms to onX property', () => {
+    const ctx: any = { scriptData: { propsTSIface: { emitTypes: [] } } };
+
+    const id = t.identifier('value');
+    id.typeAnnotation = t.tsTypeAnnotation(t.tsNumberKeyword());
+    const fnType = t.tsFunctionType(null, [id], t.tsTypeAnnotation(t.tsVoidKeyword()));
+
+    const prop = t.tsPropertySignature(t.identifier('save'), t.tsTypeAnnotation(fnType));
+    const typeLit = t.tsTypeLiteral([prop]);
+
+    const call = t.callExpression(t.identifier('defineEmits'), []);
+    (call as any).typeParameters = t.tsTypeParameterInstantiation([typeLit as any]);
+    const path: any = { node: call };
+
+    resolveDefineEmitsIface(path, ctx);
+
+    expect(ctx.scriptData.propsTSIface.emitTypes.length).toBeGreaterThan(0);
+    const lit = ctx.scriptData.propsTSIface.emitTypes[0] as any;
+    const found = lit.members.find(
+      (m: any) => (t.isIdentifier(m.key) ? m.key.name : m.key.value) === 'onSave',
+    );
+    expect(found).toBeDefined();
+  });
+
+  test('top-level interface conversion replaces call signature with props', () => {
+    const ctx: any = { scriptData: { propsTSIface: { emitTypes: [] } } };
+
+    const eventId = t.identifier('e');
+    eventId.typeAnnotation = t.tsTypeAnnotation(t.tsLiteralType(t.stringLiteral('change')));
+
+    const callSig: any = {
+      type: 'TSCallSignatureDeclaration',
+      parameters: [eventId],
+      typeAnnotation: t.tsTypeAnnotation(t.tsVoidKeyword()),
+    };
+
+    const node: any = {
+      type: 'TSInterfaceDeclaration',
+      id: t.identifier('I'),
+      body: { type: 'TSInterfaceBody', body: [callSig] },
+    };
+    const path: any = { node, parent: t.program([]) };
+
+    const visitor = resolveEmitsTopLevelTypes(ctx);
+    visitor['TSInterfaceDeclaration|TSTypeAliasDeclaration'](path as any);
+
+    const members = node.body.body as any[];
+    expect(members.length).toBeGreaterThan(0);
+    const found = members.find(
+      (m: any) => (t.isIdentifier(m.key) ? m.key.name : m.key.value) === 'onChange',
+    );
+    expect(found).toBeDefined();
+  });
+
+  test('explicit property tuple type maps to function params on handler', () => {
+    const ctx: any = { scriptData: { propsTSIface: { emitTypes: [] } } };
+
+    const tuple = t.tsTupleType([t.tsStringKeyword(), t.tsNumberKeyword()]);
+    const prop = t.tsPropertySignature(t.identifier('update'), t.tsTypeAnnotation(tuple));
+    const typeLit = t.tsTypeLiteral([prop]);
+
+    const call = t.callExpression(t.identifier('defineEmits'), []);
+    (call as any).typeParameters = t.tsTypeParameterInstantiation([typeLit as any]);
+    const path: any = { node: call };
+
+    resolveDefineEmitsIface(path, ctx);
+
+    expect(ctx.scriptData.propsTSIface.emitTypes.length).toBeGreaterThan(0);
+    const lit = ctx.scriptData.propsTSIface.emitTypes[0] as any;
+    const found = lit.members.find(
+      (m: any) => (t.isIdentifier(m.key) ? m.key.name : m.key.value) === 'onUpdate',
+    );
+    expect(found).toBeDefined();
+
+    const fnType = found.typeAnnotation.typeAnnotation as any;
+    expect(t.isTSFunctionType(fnType)).toBe(true);
+    const params = fnType.parameters;
+    expect(params.length).toBe(2);
+    const p0 = params[0] as any;
+    const p1 = params[1] as any;
+    expect(p0.typeAnnotation && t.isTSStringKeyword(p0.typeAnnotation.typeAnnotation)).toBe(true);
+    expect(p1.typeAnnotation && t.isTSNumberKeyword(p1.typeAnnotation.typeAnnotation)).toBe(true);
+  });
+
+  test('explicit TSTypeReference with nested params preserves non-emits when none present', () => {
+    const ctx: any = { scriptData: { propsTSIface: { emitTypes: [] } } };
+
+    // T<TypeA<number>> where inner type has no emits callable
+    const inner = t.tsTypeReference(
+      t.identifier('TypeA'),
+      t.tsTypeParameterInstantiation([t.tsNumberKeyword() as any]),
+    );
+    const outer = t.tsTypeReference(
+      t.identifier('Wrapper'),
+      t.tsTypeParameterInstantiation([inner as any]),
+    );
+
+    const call = t.callExpression(t.identifier('defineEmits'), []);
+    (call as any).typeParameters = t.tsTypeParameterInstantiation([outer as any]);
+    const path: any = { node: call };
+
+    resolveDefineEmitsIface(path, ctx);
+
+    // explicit non-emits types are still pushed as resolved types
+    expect(ctx.scriptData.propsTSIface.emitTypes.length).toBeGreaterThan(0);
+    const pushed = ctx.scriptData.propsTSIface.emitTypes[0] as any;
+    expect(t.isTSTypeReference(pushed)).toBe(true);
+    expect(t.isIdentifier(pushed.typeName) && pushed.typeName.name === 'Wrapper').toBe(true);
+    const params = pushed.typeParameters && pushed.typeParameters.params;
+    expect(params && params.length === 1).toBe(true);
+    const innerParam = params[0] as any;
+    expect(
+      t.isTSTypeReference(innerParam) &&
+        t.isIdentifier(innerParam.typeName) &&
+        innerParam.typeName.name === 'TypeA',
+    ).toBe(true);
+  });
+
+  test('runtime object with spread and non-string keys ignored', () => {
+    const ctx: any = { scriptData: { propsTSIface: { emitTypes: [] } } };
+
+    const prop1 = t.objectProperty(t.numericLiteral(123), t.arrayExpression([t.identifier('v')]));
+    const prop2 = t.spreadElement(t.identifier('rest'));
+    const call = t.callExpression(t.identifier('defineEmits'), [
+      t.objectExpression([prop1, prop2]),
+    ]);
+    const path: any = { node: call };
+
+    resolveDefineEmitsIface(path, ctx);
+
+    expect(ctx.scriptData.propsTSIface.emitTypes.length).toBeGreaterThan(0);
+    const lit = ctx.scriptData.propsTSIface.emitTypes[0] as any;
+    const found = lit.members.find(
+      (m: any) => (t.isIdentifier(m.key) ? m.key.name : m.key.value) === 'on123',
+    );
+    expect(found).toBeDefined();
+  });
+
+  test('top-level TSTypeReference with typeParameters containing call signature is transformed', () => {
+    const ctx: any = {};
+
+    const eventId = t.identifier('e');
+    eventId.typeAnnotation = t.tsTypeAnnotation(t.tsLiteralType(t.stringLiteral('change')));
+
+    const callSig: any = {
+      type: 'TSCallSignatureDeclaration',
+      parameters: [eventId],
+      typeAnnotation: t.tsTypeAnnotation(t.tsVoidKeyword()),
+    };
+
+    const inner: any = { type: 'TSTypeLiteral', members: [callSig] };
+
+    const typeRef = t.tsTypeReference(
+      t.identifier('Wrapper'),
+      t.tsTypeParameterInstantiation([inner as any]),
+    );
+
+    const node: any = {
+      type: 'TSTypeAliasDeclaration',
+      id: t.identifier('TRef'),
+      typeAnnotation: typeRef,
+    };
+    const path: any = { node, parent: t.program([]) };
+
+    const visitor = resolveEmitsTopLevelTypes(ctx as any);
+    visitor['TSInterfaceDeclaration|TSTypeAliasDeclaration'](path as any);
+
+    const ta = node.typeAnnotation as any;
+    expect(t.isTSTypeReference(ta)).toBe(true);
+    const param = ta.typeParameters.params[0] as any;
+    expect(t.isTSTypeLiteral(param)).toBe(true);
+    const found = (param.members as any[]).find(
+      (m: any) => (t.isIdentifier(m.key) ? m.key.name : m.key.value) === 'onChange',
+    );
+    expect(found).toBeDefined();
+  });
+
+  test('top-level union type containing call signature resolves inner param', () => {
+    const ctx: any = {};
+
+    const eventId = t.identifier('e');
+    eventId.typeAnnotation = t.tsTypeAnnotation(t.tsLiteralType(t.stringLiteral('change')));
+    const callSig: any = {
+      type: 'TSCallSignatureDeclaration',
+      parameters: [eventId],
+      typeAnnotation: t.tsTypeAnnotation(t.tsVoidKeyword()),
+    };
+    const inner: any = { type: 'TSTypeLiteral', members: [callSig] };
+
+    const union = t.tsUnionType([inner as any, t.tsNumberKeyword()]);
+    const node: any = {
+      type: 'TSTypeAliasDeclaration',
+      id: t.identifier('TU'),
+      typeAnnotation: union,
+    };
+    const path: any = { node, parent: t.program([]) };
+
+    const visitor = resolveEmitsTopLevelTypes(ctx as any);
+    visitor['TSInterfaceDeclaration|TSTypeAliasDeclaration'](path as any);
+
+    const ta = node.typeAnnotation as any;
+    expect(t.isTSUnionType(ta)).toBe(true);
+    const lit = (ta.types as any[]).find((x: any) => t.isTSTypeLiteral(x));
+    expect(lit).toBeDefined();
+    const found = (lit.members as any[]).find(
+      (m: any) => (t.isIdentifier(m.key) ? m.key.name : m.key.value) === 'onChange',
+    );
+    expect(found).toBeDefined();
+  });
+
+  test('top-level intersection type containing call signature resolves inner param', () => {
+    const ctx: any = {};
+
+    const eventId = t.identifier('e');
+    eventId.typeAnnotation = t.tsTypeAnnotation(t.tsLiteralType(t.stringLiteral('change')));
+    const callSig: any = {
+      type: 'TSCallSignatureDeclaration',
+      parameters: [eventId],
+      typeAnnotation: t.tsTypeAnnotation(t.tsVoidKeyword()),
+    };
+    const inner: any = { type: 'TSTypeLiteral', members: [callSig] };
+
+    const inter = t.tsIntersectionType([inner as any, t.tsNumberKeyword()]);
+    const node: any = {
+      type: 'TSTypeAliasDeclaration',
+      id: t.identifier('TI'),
+      typeAnnotation: inter,
+    };
+    const path: any = { node, parent: t.program([]) };
+
+    const visitor = resolveEmitsTopLevelTypes(ctx as any);
+    visitor['TSInterfaceDeclaration|TSTypeAliasDeclaration'](path as any);
+
+    const ta = node.typeAnnotation as any;
+    expect(t.isTSIntersectionType(ta)).toBe(true);
+    const lit = (ta.types as any[]).find((x: any) => t.isTSTypeLiteral(x));
+    expect(lit).toBeDefined();
+    const found = (lit.members as any[]).find(
+      (m: any) => (t.isIdentifier(m.key) ? m.key.name : m.key.value) === 'onChange',
+    );
+    expect(found).toBeDefined();
+  });
+
+  test('top-level function type alias conversion to props', () => {
+    const ctx: any = {};
+
+    const eventId = t.identifier('e');
+    eventId.typeAnnotation = t.tsTypeAnnotation(t.tsLiteralType(t.stringLiteral('change')));
+
+    const val = t.identifier('v');
+    const fnType = t.tsFunctionType(null, [eventId, val], t.tsTypeAnnotation(t.tsVoidKeyword()));
+
+    const node: any = {
+      type: 'TSTypeAliasDeclaration',
+      id: t.identifier('TFn'),
+      typeAnnotation: fnType,
+    };
+    const path: any = { node, parent: t.program([]) };
+
+    const visitor = resolveEmitsTopLevelTypes(ctx as any);
+    visitor['TSInterfaceDeclaration|TSTypeAliasDeclaration'](path as any);
+
+    const ta = node.typeAnnotation as any;
+    expect(t.isTSTypeLiteral(ta)).toBe(true);
+    const found = (ta.members as any[]).find(
+      (m: any) => (t.isIdentifier(m.key) ? m.key.name : m.key.value) === 'onChange',
+    );
+    expect(found).toBeDefined();
+  });
+
+  test('explicit property non-function type maps to single value param', () => {
+    const ctx: any = { scriptData: { propsTSIface: { emitTypes: [] } } };
+
+    const prop = t.tsPropertySignature(
+      t.identifier('save'),
+      t.tsTypeAnnotation(t.tsNumberKeyword()),
+    );
+    const typeLit = t.tsTypeLiteral([prop]);
+
+    const call = t.callExpression(t.identifier('defineEmits'), []);
+    (call as any).typeParameters = t.tsTypeParameterInstantiation([typeLit as any]);
+    const path: any = { node: call };
+
+    resolveDefineEmitsIface(path, ctx);
+
+    expect(ctx.scriptData.propsTSIface.emitTypes.length).toBeGreaterThan(0);
+    const lit = ctx.scriptData.propsTSIface.emitTypes[0] as any;
+    const found = lit.members.find(
+      (m: any) => (t.isIdentifier(m.key) ? m.key.name : m.key.value) === 'onSave',
+    );
+    expect(found).toBeDefined();
+
+    const fnType = found.typeAnnotation.typeAnnotation as any;
+    expect(t.isTSFunctionType(fnType)).toBe(true);
+    const params = fnType.parameters;
+    expect(params.length).toBe(1);
+    const p0 = params[0] as any;
+    expect(t.isIdentifier(p0)).toBe(true);
+    expect(p0.name).toBe('value');
+    expect(p0.typeAnnotation && t.isTSNumberKeyword(p0.typeAnnotation.typeAnnotation)).toBe(true);
+  });
+
+  test('runtime object tuple with spread and as-expression maps to appropriate params', () => {
+    const ctx: any = { scriptData: { propsTSIface: { emitTypes: [] } } };
+
+    const arr = t.arrayExpression([
+      t.spreadElement(t.identifier('rest')),
+      t.tsAsExpression(t.identifier('v'), t.tsNumberKeyword()),
+      t.nullLiteral(),
+    ]);
+
+    const prop = t.objectProperty(t.identifier('event'), arr);
+    const call = t.callExpression(t.identifier('defineEmits'), [t.objectExpression([prop])]);
+    const path: any = { node: call };
+
+    resolveDefineEmitsIface(path, ctx);
+
+    const lit = ctx.scriptData.propsTSIface.emitTypes[0] as any;
+    const found = lit.members.find(
+      (m: any) => (t.isIdentifier(m.key) ? m.key.name : m.key.value) === 'onEvent',
+    );
+    expect(found).toBeDefined();
+
+    const fnType = found.typeAnnotation.typeAnnotation as any;
+    const params = fnType.parameters;
+    expect(params.length).toBe(3);
+
+    const p0 = params[0];
+    expect(t.isRestElement(p0)).toBe(true);
+    const p1 = params[1] as any;
+    expect(t.isIdentifier(p1)).toBe(true);
+    expect(p1.typeAnnotation && t.isTSNumberKeyword(p1.typeAnnotation.typeAnnotation)).toBe(true);
+    const p2 = params[2] as any;
+    expect(t.isIdentifier(p2)).toBe(true);
+    expect(p2.name).toBe('arg2');
+    expect(p2.typeAnnotation && t.isTSAnyKeyword(p2.typeAnnotation.typeAnnotation)).toBe(true);
+  });
+
+  test('top-level type alias conversion replaces call signature with props', () => {
+    const ctx: any = { scriptData: { propsTSIface: { emitTypes: [] } } };
+
+    const eventId = t.identifier('e');
+    eventId.typeAnnotation = t.tsTypeAnnotation(t.tsLiteralType(t.stringLiteral('change')));
+
+    const callSig: any = {
+      type: 'TSCallSignatureDeclaration',
+      parameters: [eventId],
+      typeAnnotation: t.tsTypeAnnotation(t.tsVoidKeyword()),
+    };
+
+    const node: any = {
+      type: 'TSTypeAliasDeclaration',
+      id: t.identifier('T'),
+      typeAnnotation: { type: 'TSTypeLiteral', members: [callSig] },
+    };
+    const path: any = { node, parent: t.program([]) };
+
+    const visitor = resolveEmitsTopLevelTypes(ctx);
+    visitor['TSInterfaceDeclaration|TSTypeAliasDeclaration'](path as any);
+
+    const ta = node.typeAnnotation as any;
+    const members = ta.members as any[];
+    expect(members.length).toBeGreaterThan(0);
+    const found = members.find(
+      (m: any) => (t.isIdentifier(m.key) ? m.key.name : m.key.value) === 'onChange',
+    );
+    expect(found).toBeDefined();
+  });
+
+  test('parenthesized top-level type resolves inner call signature', () => {
+    const ctx: any = {};
+
+    const eventId = t.identifier('e');
+    eventId.typeAnnotation = t.tsTypeAnnotation(t.tsLiteralType(t.stringLiteral('change')));
+
+    const callSig: any = {
+      type: 'TSCallSignatureDeclaration',
+      parameters: [eventId],
+      typeAnnotation: t.tsTypeAnnotation(t.tsVoidKeyword()),
+    };
+
+    const paren = t.tsParenthesizedType({ type: 'TSTypeLiteral', members: [callSig] } as any);
+
+    const node: any = {
+      type: 'TSTypeAliasDeclaration',
+      id: t.identifier('TP'),
+      typeAnnotation: paren,
+    };
+    const path: any = { node, parent: t.program([]) };
+
+    const visitor = resolveEmitsTopLevelTypes(ctx as any);
+    visitor['TSInterfaceDeclaration|TSTypeAliasDeclaration'](path as any);
+
+    const ta = node.typeAnnotation as any;
+    // should be resolved to a TSTypeLiteral
+    expect(t.isTSTypeLiteral(ta)).toBe(true);
+    const found = (ta.members as any[]).find(
+      (m: any) => (t.isIdentifier(m.key) ? m.key.name : m.key.value) === 'onChange',
+    );
+    expect(found).toBeDefined();
+  });
+
+  test('TSTypeReference without typeParameters is unchanged', () => {
+    const ctx: any = {};
+    const typeRef = t.tsTypeReference(t.identifier('NoParams'));
+    const node: any = {
+      type: 'TSTypeAliasDeclaration',
+      id: t.identifier('TN'),
+      typeAnnotation: typeRef,
+    };
+    const path: any = { node, parent: t.program([]) };
+
+    const visitor = resolveEmitsTopLevelTypes(ctx as any);
+    visitor['TSInterfaceDeclaration|TSTypeAliasDeclaration'](path as any);
+
+    const ta = node.typeAnnotation as any;
+    expect(t.isTSTypeReference(ta)).toBe(true);
+  });
+
+  test('explicit function type with missing event param type produces no emit types', () => {
+    const ctx: any = { scriptData: { propsTSIface: { emitTypes: [] } } };
+
+    const fnType = t.tsFunctionType(
+      null,
+      [t.identifier('e')],
+      t.tsTypeAnnotation(t.tsVoidKeyword()),
+    );
+    const call = t.callExpression(t.identifier('defineEmits'), []);
+    (call as any).typeParameters = t.tsTypeParameterInstantiation([fnType as any]);
+    const path: any = { node: call };
+
+    resolveDefineEmitsIface(path, ctx);
+
+    expect(ctx.scriptData.propsTSIface.emitTypes.length).toBe(0);
+  });
+
+  test('explicit tuple type with rest and optional elements maps correctly', () => {
+    const ctx: any = { scriptData: { propsTSIface: { emitTypes: [] } } };
+
+    const tuple = t.tsTupleType([
+      t.tsStringKeyword(),
+      t.tsRestType(t.tsNumberKeyword()),
+      t.tsOptionalType(t.tsBooleanKeyword()),
+    ] as any);
+
+    const prop = t.tsPropertySignature(t.identifier('mixed'), t.tsTypeAnnotation(tuple));
+    const typeLit = t.tsTypeLiteral([prop]);
+
+    const call = t.callExpression(t.identifier('defineEmits'), []);
+    (call as any).typeParameters = t.tsTypeParameterInstantiation([typeLit as any]);
+    const path: any = { node: call };
+
+    resolveDefineEmitsIface(path, ctx);
+
+    const lit = ctx.scriptData.propsTSIface.emitTypes[0] as any;
+    const found = lit.members.find(
+      (m: any) => (t.isIdentifier(m.key) ? m.key.name : m.key.value) === 'onMixed',
+    );
+    expect(found).toBeDefined();
+
+    const fnType = found.typeAnnotation.typeAnnotation as any;
+    const params = fnType.parameters;
+    expect(params.length).toBe(3);
+
+    const p0 = params[0] as any;
+    expect(t.isIdentifier(p0)).toBe(true);
+    expect(p0.typeAnnotation && t.isTSStringKeyword(p0.typeAnnotation.typeAnnotation)).toBe(true);
+
+    const p1 = params[1] as any;
+    expect(t.isRestElement(p1)).toBe(true);
+    expect(p1.typeAnnotation && t.isTSNumberKeyword(p1.typeAnnotation.typeAnnotation)).toBe(true);
+
+    const p2 = params[2] as any;
+    expect(t.isIdentifier(p2)).toBe(true);
+    expect(p2.optional).toBe(true);
+    expect(p2.typeAnnotation && t.isTSBooleanKeyword(p2.typeAnnotation.typeAnnotation)).toBe(true);
+  });
+});

--- a/packages/compiler-core/src/__tests__/core/resolve-props-interface.test.ts
+++ b/packages/compiler-core/src/__tests__/core/resolve-props-interface.test.ts
@@ -1,0 +1,239 @@
+import * as t from '@babel/types';
+import { resolveDefinePropsIface } from '@core/transform/sfc/script/syntax-processor/preprocess/resolve-props-interface/resolve-props';
+import { logger } from '@shared/logger';
+
+describe('resolveDefinePropsIface', () => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+  });
+
+  test('processes array runtimeArg into propsTypes', () => {
+    const runtimeArg = t.arrayExpression([t.stringLiteral('foo')]);
+    const fakePath: any = { node: { arguments: [runtimeArg], typeParameters: undefined } };
+    const ctx: any = {
+      filename: 'x',
+      scriptData: { source: 's', propsTSIface: { propsTypes: [] } },
+    };
+
+    resolveDefinePropsIface(fakePath, ctx);
+
+    expect(ctx.scriptData.propsTSIface.propsTypes.length).toBeGreaterThan(0);
+  });
+
+  test('processes object runtimeArg into propsTypes with required flag', () => {
+    const propValue = t.objectExpression([
+      t.objectProperty(t.identifier('type'), t.identifier('String')),
+      t.objectProperty(t.identifier('required'), t.booleanLiteral(true)),
+    ]);
+
+    const runtimeArg = t.objectExpression([t.objectProperty(t.identifier('a'), propValue)]);
+    const fakePath: any = { node: { arguments: [runtimeArg], typeParameters: undefined } };
+    const ctx: any = {
+      filename: 'x',
+      scriptData: { source: 's', propsTSIface: { propsTypes: [] } },
+    };
+
+    resolveDefinePropsIface(fakePath, ctx);
+
+    expect(ctx.scriptData.propsTSIface.propsTypes.length).toBeGreaterThan(0);
+  });
+
+  test('logs error for unsupported runtimeArg', () => {
+    const runtimeArg = t.identifier('foo');
+    const fakePath: any = { node: { arguments: [runtimeArg], typeParameters: undefined } };
+    const ctx: any = {
+      filename: 'x',
+      scriptData: { source: 's', propsTSIface: { propsTypes: [] } },
+    };
+    const spy = jest.spyOn(logger, 'error').mockImplementation(() => {});
+
+    resolveDefinePropsIface(fakePath, ctx);
+
+    expect(spy).toHaveBeenCalled();
+  });
+
+  test('object runtimeArg with direct identifier type maps to Number', () => {
+    const runtimeArg = t.objectExpression([
+      t.objectProperty(t.identifier('a'), t.identifier('Number')),
+    ]);
+    const fakePath: any = { node: { arguments: [runtimeArg], typeParameters: undefined } };
+    const ctx: any = {
+      filename: 'x',
+      scriptData: { source: 's', propsTSIface: { propsTypes: [] } },
+    };
+
+    resolveDefinePropsIface(fakePath, ctx);
+
+    const pushed = ctx.scriptData.propsTSIface.propsTypes[0] as any;
+    const member = pushed.members[0] as any;
+    const ta = member.typeAnnotation.typeAnnotation;
+    expect(t.isTSNumberKeyword(ta)).toBe(true);
+  });
+
+  test('object runtimeArg with array type produces union type', () => {
+    const arr = t.arrayExpression([t.identifier('String'), t.identifier('Number')]);
+    const runtimeArg = t.objectExpression([t.objectProperty(t.identifier('a'), arr)]);
+    const fakePath: any = { node: { arguments: [runtimeArg], typeParameters: undefined } };
+    const ctx: any = {
+      filename: 'x',
+      scriptData: { source: 's', propsTSIface: { propsTypes: [] } },
+    };
+
+    resolveDefinePropsIface(fakePath, ctx);
+
+    const pushed = ctx.scriptData.propsTSIface.propsTypes[0] as any;
+    const member = pushed.members[0] as any;
+    const ta = member.typeAnnotation.typeAnnotation;
+    expect(t.isTSUnionType(ta)).toBe(true);
+    expect(ta.types.length).toBe(2);
+  });
+
+  test('numeric literal key becomes string key and empty array type -> any', () => {
+    const arr = t.arrayExpression([]);
+    const runtimeArg = t.objectExpression([t.objectProperty(t.numericLiteral(123), arr)]);
+    const fakePath: any = { node: { arguments: [runtimeArg], typeParameters: undefined } };
+    const ctx: any = {
+      filename: 'x',
+      scriptData: { source: 's', propsTSIface: { propsTypes: [] } },
+    };
+
+    resolveDefinePropsIface(fakePath, ctx);
+
+    const pushed = ctx.scriptData.propsTSIface.propsTypes[0] as any;
+    const member = pushed.members[0] as any;
+    const key = member.key;
+    expect(t.isStringLiteral(key) && key.value === '123').toBe(true);
+    const ta = member.typeAnnotation.typeAnnotation;
+    expect(t.isTSAnyKeyword(ta)).toBe(true);
+  });
+
+  test('object runtimeArg with identifier Function maps to TSFunctionType', () => {
+    const runtimeArg = t.objectExpression([
+      t.objectProperty(t.identifier('a'), t.identifier('Function')),
+    ]);
+    const fakePath: any = { node: { arguments: [runtimeArg], typeParameters: undefined } };
+    const ctx: any = {
+      filename: 'x',
+      scriptData: { source: 's', propsTSIface: { propsTypes: [] } },
+    };
+
+    resolveDefinePropsIface(fakePath, ctx);
+
+    const pushed = ctx.scriptData.propsTSIface.propsTypes[0] as any;
+    const member = pushed.members[0] as any;
+    const ta = member.typeAnnotation.typeAnnotation;
+    expect(t.isTSFunctionType(ta)).toBe(true);
+  });
+
+  test('object runtimeArg with identifier Array maps to TSArrayType', () => {
+    const runtimeArg = t.objectExpression([
+      t.objectProperty(t.identifier('a'), t.identifier('Array')),
+    ]);
+    const fakePath: any = { node: { arguments: [runtimeArg], typeParameters: undefined } };
+    const ctx: any = {
+      filename: 'x',
+      scriptData: { source: 's', propsTSIface: { propsTypes: [] } },
+    };
+
+    resolveDefinePropsIface(fakePath, ctx);
+
+    const pushed = ctx.scriptData.propsTSIface.propsTypes[0] as any;
+    const member = pushed.members[0] as any;
+    const ta = member.typeAnnotation.typeAnnotation;
+    expect(t.isTSArrayType(ta)).toBe(true);
+    expect(t.isTSAnyKeyword(ta.elementType)).toBe(true);
+  });
+
+  test('object runtimeArg with identifier Object maps to TSTypeLiteral', () => {
+    const runtimeArg = t.objectExpression([
+      t.objectProperty(t.identifier('a'), t.identifier('Object')),
+    ]);
+    const fakePath: any = { node: { arguments: [runtimeArg], typeParameters: undefined } };
+    const ctx: any = {
+      filename: 'x',
+      scriptData: { source: 's', propsTSIface: { propsTypes: [] } },
+    };
+
+    resolveDefinePropsIface(fakePath, ctx);
+
+    const pushed = ctx.scriptData.propsTSIface.propsTypes[0] as any;
+    const member = pushed.members[0] as any;
+    const ta = member.typeAnnotation.typeAnnotation;
+    expect(t.isTSTypeLiteral(ta)).toBe(true);
+  });
+
+  test('object runtimeArg Symbol and BigInt map to symbol and bigint keywords', () => {
+    const runtimeArg = t.objectExpression([
+      t.objectProperty(t.identifier('s'), t.identifier('Symbol')),
+      t.objectProperty(t.identifier('b'), t.identifier('BigInt')),
+    ]);
+    const fakePath: any = { node: { arguments: [runtimeArg], typeParameters: undefined } };
+    const ctx: any = {
+      filename: 'x',
+      scriptData: { source: 's', propsTSIface: { propsTypes: [] } },
+    };
+
+    resolveDefinePropsIface(fakePath, ctx);
+
+    const pushed = ctx.scriptData.propsTSIface.propsTypes[0] as any;
+    const symbolMember = pushed.members.find(
+      (m: any) => t.isIdentifier(m.key) && m.key.name === 's',
+    );
+    const bigintMember = pushed.members.find(
+      (m: any) => t.isIdentifier(m.key) && m.key.name === 'b',
+    );
+    expect(t.isTSSymbolKeyword(symbolMember.typeAnnotation.typeAnnotation)).toBe(true);
+    expect(t.isTSBigIntKeyword(bigintMember.typeAnnotation.typeAnnotation)).toBe(true);
+  });
+
+  test('unknown identifier maps to any keyword', () => {
+    const runtimeArg = t.objectExpression([
+      t.objectProperty(t.identifier('x'), t.identifier('Custom')),
+    ]);
+    const fakePath: any = { node: { arguments: [runtimeArg], typeParameters: undefined } };
+    const ctx: any = {
+      filename: 'x',
+      scriptData: { source: 's', propsTSIface: { propsTypes: [] } },
+    };
+
+    resolveDefinePropsIface(fakePath, ctx);
+
+    const pushed = ctx.scriptData.propsTSIface.propsTypes[0] as any;
+    const member = pushed.members[0] as any;
+    expect(t.isTSAnyKeyword(member.typeAnnotation.typeAnnotation)).toBe(true);
+  });
+
+  test('array type with single identifier returns single type (not union)', () => {
+    const arr = t.arrayExpression([t.identifier('Number')]);
+    const runtimeArg = t.objectExpression([t.objectProperty(t.identifier('a'), arr)]);
+    const fakePath: any = { node: { arguments: [runtimeArg], typeParameters: undefined } };
+    const ctx: any = {
+      filename: 'x',
+      scriptData: { source: 's', propsTSIface: { propsTypes: [] } },
+    };
+
+    resolveDefinePropsIface(fakePath, ctx);
+
+    const pushed = ctx.scriptData.propsTSIface.propsTypes[0] as any;
+    const member = pushed.members[0] as any;
+    const ta = member.typeAnnotation.typeAnnotation;
+    expect(t.isTSNumberKeyword(ta)).toBe(true);
+  });
+
+  test('array type with non-identifier elements filters them out', () => {
+    const arr = t.arrayExpression([t.stringLiteral('a'), t.identifier('Number')]);
+    const runtimeArg = t.objectExpression([t.objectProperty(t.identifier('a'), arr)]);
+    const fakePath: any = { node: { arguments: [runtimeArg], typeParameters: undefined } };
+    const ctx: any = {
+      filename: 'x',
+      scriptData: { source: 's', propsTSIface: { propsTypes: [] } },
+    };
+
+    resolveDefinePropsIface(fakePath, ctx);
+
+    const pushed = ctx.scriptData.propsTSIface.propsTypes[0] as any;
+    const member = pushed.members[0] as any;
+    const ta = member.typeAnnotation.typeAnnotation;
+    expect(t.isTSNumberKeyword(ta)).toBe(true);
+  });
+});

--- a/packages/compiler-core/src/__tests__/core/resolve-props.test.ts
+++ b/packages/compiler-core/src/__tests__/core/resolve-props.test.ts
@@ -1,0 +1,44 @@
+import * as attrMod from '@core/transform/sfc/template/syntax-processor/process/props/resolve-attribute-prop';
+import * as dirMod from '@core/transform/sfc/template/syntax-processor/process/props/resolve-directive-prop';
+import { resolveProps } from '@core/transform/sfc/template/syntax-processor/process/props/resolve-props';
+import { NodeTypes } from '@vue/compiler-core';
+
+describe('resolveProps', () => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+  });
+
+  test('calls resolveAttributeProp for attributes and resolveDirectiveProp for directives', () => {
+    const resolveAttrSpy = jest.spyOn(attrMod, 'resolveAttributeProp').mockImplementation(() => {});
+    const resolveDirSpy = jest
+      .spyOn(dirMod, 'resolveDirectiveProp')
+      .mockImplementation(() => false);
+
+    const vueNode: any = { props: [{ type: NodeTypes.ATTRIBUTE }, { type: NodeTypes.DIRECTIVE }] };
+    const ir: any = {};
+    const ctx: any = {};
+    const nodeIR: any = {};
+    const siblingNodesIR: any[] = [];
+
+    resolveProps(vueNode, ir, ctx, nodeIR, siblingNodesIR);
+
+    expect(resolveAttrSpy).toHaveBeenCalledTimes(1);
+    expect(resolveDirSpy).toHaveBeenCalledTimes(1);
+  });
+
+  test('stops processing when resolveDirectiveProp returns true', () => {
+    const resolveAttrSpy = jest.spyOn(attrMod, 'resolveAttributeProp').mockImplementation(() => {});
+    const resolveDirSpy = jest.spyOn(dirMod, 'resolveDirectiveProp').mockImplementation(() => true);
+
+    const vueNode: any = { props: [{ type: NodeTypes.DIRECTIVE }, { type: NodeTypes.DIRECTIVE }] };
+    const ir: any = {};
+    const ctx: any = {};
+    const nodeIR: any = {};
+    const siblingNodesIR: any[] = [];
+
+    resolveProps(vueNode, ir, ctx, nodeIR, siblingNodesIR);
+
+    expect(resolveDirSpy).toHaveBeenCalledTimes(1);
+    expect(resolveAttrSpy).not.toHaveBeenCalled();
+  });
+});

--- a/packages/compiler-core/src/__tests__/core/slot-builder.test.ts
+++ b/packages/compiler-core/src/__tests__/core/slot-builder.test.ts
@@ -1,0 +1,46 @@
+import * as t from '@babel/types';
+import {
+  buildSlotPropSignature,
+  createSlotScopeParam,
+} from '@core/transform/sfc/script/syntax-processor/preprocess/resolve-props-interface/resolve-slot/slot-builder';
+
+describe('slot-builder', () => {
+  test('buildSlotPropSignature creates children for default no-params', () => {
+    const sig = buildSlotPropSignature('default', [], false);
+    expect(t.isTSPropertySignature(sig)).toBe(true);
+    const key = sig.key as any;
+    expect(t.isIdentifier(key) ? key.name : key.value).toBe('children');
+    expect(sig.optional).toBe(false);
+  });
+
+  test('buildSlotPropSignature creates function type for scoped slot', () => {
+    const param = t.identifier('p');
+    const sig = buildSlotPropSignature('foo', [param], true);
+    expect(t.isTSPropertySignature(sig)).toBe(true);
+    const key = sig.key as any;
+    expect(t.isIdentifier(key) ? key.name : key.value).toBe('foo');
+    expect(sig.optional).toBe(true);
+    const ta = sig.typeAnnotation as any;
+    expect(t.isTSTypeAnnotation(ta)).toBe(true);
+    expect(t.isTSFunctionType(ta.typeAnnotation)).toBe(true);
+  });
+
+  test('createSlotScopeParam builds param with reactive binding types', () => {
+    const props = [
+      { prop: 'a', tsType: t.tsTypeAnnotation(t.tsNumberKeyword()) },
+      { prop: 'b-c', tsType: t.tsTypeAnnotation(t.tsStringKeyword()) },
+    ];
+
+    const ctx: any = { templateData: { reactiveBindings: { a: { value: t.numericLiteral(1) } } } };
+
+    const id = createSlotScopeParam(props as any, ctx as any);
+    expect(t.isIdentifier(id)).toBe(true);
+    expect(id.typeAnnotation).toBeDefined();
+    const ta = id.typeAnnotation as any;
+    expect(t.isTSTypeAnnotation(ta)).toBe(true);
+    const lit = ta.typeAnnotation as any;
+    expect(t.isTSTypeLiteral(lit)).toBe(true);
+    const keys = lit.members.map((m: any) => (t.isIdentifier(m.key) ? m.key.name : m.key.value));
+    expect(keys).toEqual(expect.arrayContaining(['a', 'b-c']));
+  });
+});

--- a/packages/compiler-core/src/__tests__/core/style-only.test.ts
+++ b/packages/compiler-core/src/__tests__/core/style-only.test.ts
@@ -1,0 +1,56 @@
+import { parseOnlyStyle } from '@core/parse/style-only';
+import { resolveLessSass } from '@plugins/resolve-less-sass';
+import { logger } from '@shared/logger';
+import { executePlugins } from '@shared/plugin-executor';
+
+jest.mock('@plugins/resolve-less-sass', () => ({
+  resolveLessSass: jest.fn(),
+}));
+
+jest.mock('@shared/plugin-executor', () => ({
+  executePlugins: jest.fn(),
+}));
+
+describe('parseOnlyStyle', () => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+  });
+
+  test('returns parsed style with resolved code and lang', () => {
+    (resolveLessSass as unknown as jest.Mock).mockReturnValue({
+      code: '/* css */',
+      fileExt: '.css',
+    });
+    const ctx: any = { filename: 'a.css', preprocessStyles: false };
+    const res = parseOnlyStyle('some source', ctx, {} as any);
+    expect(res.style?.source?.content).toBe('/* css */');
+    expect(res.style?.source?.lang).toBe('css');
+  });
+
+  test('fallbacks filename without extension and warns', () => {
+    (resolveLessSass as unknown as jest.Mock).mockReturnValue({
+      code: '/* less */',
+      fileExt: '.less',
+    });
+    const warnSpy = jest.spyOn(logger, 'warn').mockImplementation(() => {});
+    const ctx: any = { filename: 'a.', preprocessStyles: true };
+    parseOnlyStyle('source', ctx, {} as any);
+    expect(warnSpy).toHaveBeenCalled();
+    expect(resolveLessSass).toHaveBeenCalledWith('source', {
+      filename: 'a.',
+      lang: 'css',
+      enabled: true,
+    });
+  });
+
+  test('executePlugins is called with provided plugins', () => {
+    (resolveLessSass as unknown as jest.Mock).mockReturnValue({
+      code: '/* css */',
+      fileExt: '.css',
+    });
+    const plugins = [() => {}];
+    const ctx: any = { filename: 'b.css', preprocessStyles: false };
+    parseOnlyStyle('src', ctx, { plugins } as any);
+    expect(executePlugins).toHaveBeenCalledWith(plugins, expect.anything(), ctx);
+  });
+});

--- a/packages/compiler-core/src/__tests__/core/style-utils.test.ts
+++ b/packages/compiler-core/src/__tests__/core/style-utils.test.ts
@@ -1,0 +1,33 @@
+import { isSimpleStyle, parseStyleString } from '@core/transform/sfc/template/shared/style-utils';
+
+describe('style-utils', () => {
+  test('isSimpleStyle recognizes Object.assign and object literals', () => {
+    expect(isSimpleStyle('Object.assign({}, a)')).toBe(true);
+    expect(isSimpleStyle('{a:1}')).toBe(true);
+    expect(isSimpleStyle('color:red')).toBe(false);
+    expect(isSimpleStyle('')).toBe(false);
+  });
+
+  test('parseStyleString returns simple styles unchanged', () => {
+    expect(parseStyleString('Object.assign({}, a)')).toBe('Object.assign({}, a)');
+    expect(parseStyleString('{a:1}')).toBe('{a:1}');
+  });
+
+  test('parseStyleString returns identifier unchanged', () => {
+    expect(parseStyleString('foo')).toBe('foo');
+  });
+
+  test('parseStyleString handles empty trimmed string', () => {
+    expect(parseStyleString('   ')).toBe('{}');
+  });
+
+  test('parseStyleString parses css text into object literal', () => {
+    const css = 'color: red; background-color: blue;';
+    expect(parseStyleString(css)).toBe("{color: 'red',backgroundColor: 'blue'}");
+  });
+
+  test('parseStyleString ignores invalid entries', () => {
+    const css = ';;color: green;invalid; padding: 0px;';
+    expect(parseStyleString(css)).toBe("{color: 'green',padding: '0px'}");
+  });
+});

--- a/packages/compiler-core/src/__tests__/core/trace-utils.test.ts
+++ b/packages/compiler-core/src/__tests__/core/trace-utils.test.ts
@@ -1,0 +1,126 @@
+import * as t from '@babel/types';
+import * as depChecker from '@core/transform/sfc/script/shared/dependency-analyzer/dep-checker';
+import { traceBindingSource } from '@core/transform/sfc/script/shared/dependency-analyzer/trace-utils';
+
+describe('trace-utils', () => {
+  beforeEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  test('identifier init sourced from eligible binding returns identifier', () => {
+    const sourceBinding: any = {};
+
+    jest
+      .spyOn(depChecker, 'isEligibleBindingSource')
+      .mockImplementation((b: any) => b === sourceBinding);
+
+    const binding: any = {
+      path: {
+        isVariableDeclarator: () => true,
+        node: { init: t.identifier('state') },
+        scope: { getBinding: (name: string) => (name === 'state' ? sourceBinding : null) },
+      },
+    };
+
+    const res = traceBindingSource(binding as any, new Set(), 2);
+    expect(res).not.toBeNull();
+    expect(t.isIdentifier(res!)).toBe(true);
+    expect((res as t.Identifier).name).toBe('state');
+  });
+
+  test('member expression with eligible root returns cloned member expression', () => {
+    const sourceBinding: any = {};
+    jest
+      .spyOn(depChecker, 'isEligibleBindingSource')
+      .mockImplementation((b: any) => b === sourceBinding);
+
+    const binding: any = {
+      path: {
+        isVariableDeclarator: () => true,
+        node: { init: t.memberExpression(t.identifier('state'), t.identifier('count')) },
+        scope: { getBinding: (name: string) => (name === 'state' ? sourceBinding : null) },
+      },
+    };
+
+    const res = traceBindingSource(binding as any, new Set(), 2);
+    expect(res).not.toBeNull();
+    expect(t.isMemberExpression(res!)).toBe(true);
+    const me = res as t.MemberExpression;
+    expect(t.isIdentifier(me.object) && (me.object as t.Identifier).name === 'state').toBe(true);
+    expect(t.isIdentifier(me.property) && (me.property as t.Identifier).name === 'count').toBe(
+      true,
+    );
+  });
+
+  test('member expression rebuilds when root is local binding pointing to eligible source', () => {
+    const stateBinding: any = { _id: 'state' };
+    const aBinding: any = { _id: 'a' };
+
+    // isEligibleBindingSource returns true only for the ultimate stateBinding
+    jest
+      .spyOn(depChecker, 'isEligibleBindingSource')
+      .mockImplementation((b: any) => b === stateBinding);
+
+    const bindingA: any = {
+      path: {
+        isVariableDeclarator: () => true,
+        node: { init: t.identifier('state') },
+        scope: { getBinding: (name: string) => (name === 'state' ? stateBinding : null) },
+      },
+    };
+
+    const bindingB: any = {
+      path: {
+        isVariableDeclarator: () => true,
+        node: { init: t.memberExpression(t.identifier('a'), t.identifier('count')) },
+        scope: { getBinding: (name: string) => (name === 'a' ? bindingA : null) },
+      },
+    };
+
+    const res = traceBindingSource(bindingB as any, new Set(), 4);
+    expect(res).not.toBeNull();
+    expect(t.isMemberExpression(res!)).toBe(true);
+    const me = res as t.MemberExpression;
+    expect(t.isIdentifier(me.object) && (me.object as t.Identifier).name === 'state').toBe(true);
+    expect(t.isIdentifier(me.property) && (me.property as t.Identifier).name === 'count').toBe(
+      true,
+    );
+  });
+
+  test('rebuildMemberWithNewRoot returns null for unsupported object types', () => {
+    // create an OptionalMemberExpression whose object is a Literal (unsupported)
+    const node: any = t.optionalMemberExpression(
+      t.stringLiteral('str') as any,
+      t.identifier('x'),
+      false,
+      true,
+    );
+    const nextRoot = t.identifier('state');
+
+    // call internal function via casting (simulate private use)
+    // export not available; we invoke by importing module and accessing function via require cache is not feasible here
+    // Instead test behavior via traceBindingSource path where rebuild will attempt replacement and fail
+
+    const binding: any = {
+      path: {
+        isVariableDeclarator: () => true,
+        node: { init: node },
+        scope: {
+          getBinding: () => ({ path: { node: { init: t.identifier('state') }, scope: {} } }),
+        },
+      },
+    };
+
+    // stub dep-checker to mark root as eligible so rebuild path runs
+    jest
+      .spyOn(
+        require('@core/transform/sfc/script/shared/dependency-analyzer/dep-checker'),
+        'isEligibleBindingSource',
+      )
+      .mockImplementation(() => true);
+
+    const res = traceBindingSource(binding as any, new Set(), 3);
+    // unsupported object type should result in null
+    expect(res).toBeNull();
+  });
+});

--- a/packages/compiler-core/src/__tests__/core/type-resolver.test.ts
+++ b/packages/compiler-core/src/__tests__/core/type-resolver.test.ts
@@ -1,0 +1,135 @@
+import * as t from '@babel/types';
+import {
+  resolveSlotPropFromMember,
+  resolveSlotType,
+} from '@core/transform/sfc/script/syntax-processor/preprocess/resolve-props-interface/resolve-slot/type-resolver';
+
+describe('type-resolver', () => {
+  test('resolveSlotType with function type returns default children prop', () => {
+    const fnType = t.tsFunctionType(null, [], t.tsTypeAnnotation(t.tsVoidKeyword()));
+    const options: any = { localTypeDeclarations: new Map(), visitedTypeNames: new Set() };
+
+    const res = resolveSlotType(fnType, options as any);
+
+    expect(res.shouldRecordReactNode).toBe(true);
+    expect(t.isTSTypeLiteral(res.type)).toBe(true);
+
+    const members = (res.type as any).members;
+    expect(members.length).toBe(1);
+    const key = members[0].key;
+    expect(t.isIdentifier(key) ? key.name : key.value).toBe('children');
+  });
+
+  test('resolveSlotType with object literal containing callable property', () => {
+    const fnType = t.tsFunctionType(
+      null,
+      [t.identifier('p')],
+      t.tsTypeAnnotation(t.tsVoidKeyword()),
+    );
+    const propSig = t.tsPropertySignature(t.identifier('foo'), t.tsTypeAnnotation(fnType));
+    const tsLiteral = t.tsTypeLiteral([propSig]);
+    const options: any = { localTypeDeclarations: new Map(), visitedTypeNames: new Set() };
+
+    const res = resolveSlotType(tsLiteral, options as any);
+    expect(res.shouldRecordReactNode).toBe(true);
+    expect(t.isTSTypeLiteral(res.type)).toBe(true);
+
+    const members = (res.type as any).members;
+    const key = members[0].key;
+    expect(t.isIdentifier(key) ? key.name : key.value).toBe('foo');
+  });
+
+  test('resolveSlotPropFromMember handles method signature', () => {
+    const method: any = {
+      type: 'TSMethodSignature',
+      key: t.identifier('bar'),
+      parameters: [t.identifier('a')],
+    };
+
+    const res = resolveSlotPropFromMember(method as any);
+    expect(res.shouldRecordReactNode).toBe(true);
+    expect(res.member).not.toBeNull();
+    const key = (res.member as any).key;
+    expect(t.isIdentifier(key) ? key.name : key.value).toBe('bar');
+  });
+
+  test('resolveSlotType with type reference param that is function type', () => {
+    const fnType = t.tsFunctionType(
+      null,
+      [t.identifier('p')],
+      t.tsTypeAnnotation(t.tsVoidKeyword()),
+    );
+    const typeRef = t.tsTypeReference(
+      t.identifier('X'),
+      t.tsTypeParameterInstantiation([fnType as any]),
+    );
+    const options: any = { localTypeDeclarations: new Map(), visitedTypeNames: new Set() };
+
+    const res = resolveSlotType(typeRef, options as any);
+    expect(res.shouldRecordReactNode).toBe(true);
+    expect(t.isTSTypeReference(res.type)).toBe(true);
+    const params = (res.type as any).typeParameters.params;
+    expect(params.length).toBeGreaterThan(0);
+    expect(t.isTSTypeLiteral(params[0])).toBe(true);
+  });
+
+  test('resolveSlotType with intersection of callable types returns intersection', () => {
+    const fn1 = t.tsFunctionType(null, [t.identifier('a')], t.tsTypeAnnotation(t.tsVoidKeyword()));
+    const fn2 = t.tsFunctionType(null, [t.identifier('b')], t.tsTypeAnnotation(t.tsVoidKeyword()));
+    const inter = t.tsIntersectionType([fn1 as any, fn2 as any]);
+    const options: any = { localTypeDeclarations: new Map(), visitedTypeNames: new Set() };
+
+    const res = resolveSlotType(inter, options as any);
+    expect(res.shouldRecordReactNode).toBe(true);
+    expect(t.isTSIntersectionType(res.type)).toBe(true);
+  });
+
+  test('resolveSlotType with union of callable types returns union', () => {
+    const fn1 = t.tsFunctionType(null, [t.identifier('a')], t.tsTypeAnnotation(t.tsVoidKeyword()));
+    const fn2 = t.tsFunctionType(null, [t.identifier('b')], t.tsTypeAnnotation(t.tsVoidKeyword()));
+    const uni = t.tsUnionType([fn1 as any, fn2 as any]);
+    const options: any = { localTypeDeclarations: new Map(), visitedTypeNames: new Set() };
+
+    const res = resolveSlotType(uni, options as any);
+    expect(res.shouldRecordReactNode).toBe(true);
+    expect(t.isTSUnionType(res.type)).toBe(true);
+  });
+
+  test('resolveSlotType with type literal containing call signature yields children prop', () => {
+    const callSig: any = { type: 'TSCallSignatureDeclaration', parameters: [t.identifier('x')] };
+    const lit = t.tsTypeLiteral([callSig as any]);
+    const options: any = { localTypeDeclarations: new Map(), visitedTypeNames: new Set() };
+
+    const res = resolveSlotType(lit, options as any);
+    expect(res.shouldRecordReactNode).toBe(true);
+    expect(t.isTSTypeLiteral(res.type)).toBe(true);
+    const members = (res.type as any).members;
+    // default call signature should produce a children prop (default slot)
+    const found = members.find(
+      (m: any) => (t.isIdentifier(m.key) ? m.key.name : m.key.value) === 'children',
+    );
+    expect(found).toBeDefined();
+  });
+
+  test('resolveSlotPropFromMember returns null for unknown member types', () => {
+    const unknown: any = { type: 'TSUnknown' };
+    const res = resolveSlotPropFromMember(unknown as any);
+    expect(res.shouldRecordReactNode).toBe(false);
+    expect(res.member).toBeNull();
+  });
+
+  test('resolveSlotType detects and avoids recursive local type declarations', () => {
+    const localMap = new Map<string, any>();
+    // A -> B, B -> A to create recursion
+    localMap.set('A', { type: t.tsTypeReference(t.identifier('B')), hasTypeParameters: false });
+    localMap.set('B', { type: t.tsTypeReference(t.identifier('A')), hasTypeParameters: false });
+
+    const options: any = { localTypeDeclarations: localMap, visitedTypeNames: new Set() };
+    const ref = t.tsTypeReference(t.identifier('A'));
+
+    const res = resolveSlotType(ref, options as any);
+    // should not record ReactNode due to recursion protection
+    expect(res.shouldRecordReactNode).toBe(false);
+    expect(t.isTSTypeReference(res.type)).toBe(true);
+  });
+});

--- a/packages/compiler-core/src/__tests__/plugins/prettier.test.ts
+++ b/packages/compiler-core/src/__tests__/plugins/prettier.test.ts
@@ -1,0 +1,22 @@
+import { simpleFormat } from '@plugins/prettier';
+
+describe('plugins/prettier', () => {
+  test('simpleFormat compresses multiple blank lines and ensures trailing newline', () => {
+    const input = 'a\n\n\n\nbar';
+    const out = simpleFormat(input);
+    expect(out.endsWith('\n')).toBe(true);
+    // collapsed to at most two blank lines
+    expect(out).toContain('\n\nbar');
+  });
+
+  test('formatWithPrettier uses prettier when available', async () => {
+    // mock prettier module dynamically for this test
+    jest.isolateModules(async () => {
+      jest.doMock('prettier', () => ({ format: (code: string) => `P:${code}` }), { virtual: true });
+      const mod = await import('@plugins/prettier');
+      const out = await mod.formatWithPrettier('x', 'js');
+      expect(out).toBe('P:x');
+      jest.dontMock('prettier');
+    });
+  });
+});

--- a/packages/compiler-core/src/__tests__/shared/logger.test.ts
+++ b/packages/compiler-core/src/__tests__/shared/logger.test.ts
@@ -1,0 +1,39 @@
+import { Logger } from '@shared/logger';
+
+describe('shared/logger', () => {
+  test('add logs, query and clear', () => {
+    const l = new Logger();
+    l.warn('w', { file: 'f.ts', loc: { start: { line: 2, column: 1 } }, source: 'a\nb\nc' });
+    l.error('e');
+    l.info('i');
+
+    const logs = l.getLogs();
+    expect(logs.length).toBe(3);
+    expect(l.hasErrors()).toBe(true);
+    expect(l.hasWarnings()).toBe(true);
+
+    l.clear();
+    expect(l.getLogs().length).toBe(0);
+  });
+
+  test('printAll prints context and summary', () => {
+    const l = new Logger();
+    const spy = jest.spyOn(console, 'log').mockImplementation(() => {});
+    try {
+      l.error('err', {
+        file: 'file.ts',
+        loc: { start: { line: 2, column: 1 } },
+        source: 'one\ntwo\nthree',
+      });
+      l.warn('warn', { file: 'file.ts' });
+      l.printAll();
+
+      expect(spy).toHaveBeenCalled();
+      const calls = spy.mock.calls.flat().join(' ');
+      // pointer caret should be present in context output
+      expect(calls).toMatch(/\^/);
+    } finally {
+      spy.mockRestore();
+    }
+  });
+});

--- a/packages/compiler-core/src/__tests__/shared/plugin-executor.test.ts
+++ b/packages/compiler-core/src/__tests__/shared/plugin-executor.test.ts
@@ -1,0 +1,26 @@
+import { executePlugins } from '@shared/plugin-executor';
+
+describe('shared/plugin-executor', () => {
+  test('executes plugins and swallows exceptions', () => {
+    const result: any = {};
+    const ctx = { x: 1 };
+
+    const map: any = {
+      ok: (r: any) => {
+        r.ok = true;
+      },
+      bad: () => {
+        throw new Error('fail');
+      },
+    };
+
+    const spy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    try {
+      executePlugins(map, result, ctx);
+      expect(result.ok).toBe(true);
+      expect(spy).toHaveBeenCalled();
+    } finally {
+      spy.mockRestore();
+    }
+  });
+});

--- a/packages/compiler-core/src/__tests__/shared/string-code-types.test.ts
+++ b/packages/compiler-core/src/__tests__/shared/string-code-types.test.ts
@@ -1,0 +1,24 @@
+import { isIdentifier, isSimpleExpression, isStringLiteral } from '@shared/string-code-types';
+
+describe('shared/string-code-types', () => {
+  test('isSimpleExpression recognizes literals and identifiers', () => {
+    expect(isSimpleExpression('123')).toBe(true);
+    expect(isSimpleExpression("'abc'")).toBe(true);
+    expect(isSimpleExpression('myVar')).toBe(true);
+  });
+
+  test('isSimpleExpression handles member expressions and complex cases', () => {
+    // current implementation does not recursively parse member.object, so it's false
+    expect(isSimpleExpression('obj.prop')).toBe(false);
+    expect(isSimpleExpression('{ a: 1 }')).toBe(false);
+    expect(isSimpleExpression('fn()')).toBe(false);
+  });
+
+  test('isIdentifier and isStringLiteral behaviors', () => {
+    expect(isIdentifier('foo')).toBe(true);
+    expect(isIdentifier('1 + 1')).toBe(false);
+
+    expect(isStringLiteral("'str'")).toBe(true);
+    expect(isStringLiteral('`templ${v}`')).toBe(false);
+  });
+});

--- a/packages/compiler-core/src/__tests__/utils/hash.test.ts
+++ b/packages/compiler-core/src/__tests__/utils/hash.test.ts
@@ -1,0 +1,25 @@
+import { genHashByXXH, randomHash } from '@utils/hash';
+
+describe('utils/hash', () => {
+  test('genHashByXXH is deterministic and returns hex string', () => {
+    const v1 = genHashByXXH('hello-world');
+    const v2 = genHashByXXH('hello-world');
+    expect(typeof v1).toBe('string');
+    expect(v1).toMatch(/^[0-9a-f]+$/i);
+    expect(v1).toBe(v2);
+  });
+
+  test('randomHash with mocked Math.random produces deterministic output', () => {
+    const orig = Math.random;
+    try {
+      // force Math.random to always return 0 so we pick first char repeatedly
+      (Math as any).random = jest.fn().mockReturnValue(0);
+      const r = randomHash(5);
+      expect(r).toHaveLength(5);
+      const charsetFirst = 'ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnpqrstuvwxyz23456789'.charAt(0);
+      expect(r).toBe(charsetFirst.repeat(5));
+    } finally {
+      (Math as any).random = orig;
+    }
+  });
+});


### PR DESCRIPTION
文件：22 个（+2149 行），新增编译器、核心工具、插件、共享模块等测试用例