### PR TITLE
Enhance withDefaults support and improve API handling

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -6,10 +6,10 @@
 
 **Write Vue. Get Pure React.**
 
-> A complete solution for Vue-to-React migration and hybrid development.
+> A smart compiler built for migrating Vue to React.
 >
-> It converts Vue 3 SFCs, scripts, and styles into pure React without a runtime bridge, with full
-> `<script setup>` support and progressive migration.
+> Converts Vue 3 Components, Scripts, and Styles into pure React (no runtime bridge),
+> supporting progressive migration and Vue+React hybrid development.
 
 [![Npm](https://img.shields.io/npm/v/@vureact/compiler-core.svg?label=Npm&style=flat-square)](https://vureact.top/en/)
 [![Stars](https://img.shields.io/github/stars/vureact-js/core?style=flat-square&logo=github)](https://github.com/vureact-js/core/stargazers)

--- a/README.en.md
+++ b/README.en.md
@@ -11,11 +11,10 @@
 > Converts Vue 3 Components, Scripts, and Styles into pure React (no runtime bridge),
 > supporting progressive migration and Vue+React hybrid development.
 
-[![Npm](https://img.shields.io/npm/v/@vureact/compiler-core.svg?label=Npm&style=flat-square)](https://vureact.top/)
-[![Stars](https://img.shields.io/github/stars/vureact-js/core?color=white&style=flat-square&logo=github)](https://github.com/vureact-js/core/stargazers)
-[![Monthly](https://img.shields.io/npm/dm/@vureact/compiler-core?label=Monthly&style=flat-square)](https://www.npmjs.com/package/@vureact/compiler-core)
-[![Downloads](https://img.shields.io/npm/dt/@vureact/compiler-core?label=Downloads&style=flat-square&color=red)](https://www.npmjs.com/package/@vureact/compiler-core)
-[![Coverage](https://codecov.io/gh/vureact-js/core/graph/badge.svg?flag=compiler-core&style=flat-square)](https://codecov.io/gh/vureact-js/core)
+[![Npm](https://img.shields.io/npm/v/@vureact/compiler-core.svg?label=Npm)](https://vureact.top/)
+[![Stars](https://img.shields.io/github/stars/vureact-js/core?color=white&logo=github&style=flat-square)](https://github.com/vureact-js/core/stargazers)
+[![Downloads](https://img.shields.io/npm/dt/@vureact/compiler-core?label=Downloads)](https://www.npmjs.com/package/@vureact/compiler-core)
+[![Coverage](https://codecov.io/gh/vureact-js/core/graph/badge.svg?flag=compiler-core)](https://codecov.io/gh/vureact-js/core)
 [![Node](https://img.shields.io/badge/node-%3E%3D20.19.0-green?label=Node)](https://nodejs.org/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://github.com/vureact-js/core/blob/master/LICENSE)
 

--- a/README.en.md
+++ b/README.en.md
@@ -11,15 +11,13 @@
 > Converts Vue 3 Components, Scripts, and Styles into pure React (no runtime bridge),
 > supporting progressive migration and Vue+React hybrid development.
 
-[![Npm](https://img.shields.io/npm/v/@vureact/compiler-core.svg?label=Npm&style=flat-square)](https://vureact.top/en/)
-[![Stars](https://img.shields.io/github/stars/vureact-js/core?style=flat-square&logo=github)](https://github.com/vureact-js/core/stargazers)
-[![Downloads](https://img.shields.io/npm/dt/@vureact/compiler-core?label=Downloads&style=flat-square&color=red)](https://www.npmjs.com/package/@vureact/compiler-core)
+[![Npm](https://img.shields.io/npm/v/@vureact/compiler-core.svg?label=Npm&style=flat-square)](https://vureact.top/)
+[![Stars](https://img.shields.io/github/stars/vureact-js/core?color=white&style=flat-square&logo=github)](https://github.com/vureact-js/core/stargazers)
 [![Monthly](https://img.shields.io/npm/dm/@vureact/compiler-core?label=Monthly&style=flat-square)](https://www.npmjs.com/package/@vureact/compiler-core)
+[![Downloads](https://img.shields.io/npm/dt/@vureact/compiler-core?label=Downloads&style=flat-square&color=red)](https://www.npmjs.com/package/@vureact/compiler-core)
 [![Coverage](https://codecov.io/gh/vureact-js/core/graph/badge.svg?flag=compiler-core&style=flat-square)](https://codecov.io/gh/vureact-js/core)
 [![Node](https://img.shields.io/badge/node-%3E%3D20.19.0-green?label=Node)](https://nodejs.org/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://github.com/vureact-js/core/blob/master/LICENSE)
-[![Vue 3](https://img.shields.io/badge/Vue-3.x-42b883)](https://vuejs.org/)
-[![React 18+](https://img.shields.io/badge/React-18%2B-61dafb)](https://reactjs.org/)
 
 [Online Playground](#️-online-playground-no-install) · [Quick Start](#-quick-start) · [Use Cases](#-use-cases) · [Ecosystem](#️-ecosystem) · [Compilation Conventions](https://vureact.top/en/guide/specification.html) · [Semantic Comparison](https://vureact.top/en/guide/semantic-comparison/overview.html) · [Changelog](https://vureact.top/en/guide/changelog.html)
 

--- a/README.ja.md
+++ b/README.ja.md
@@ -6,9 +6,10 @@
 
 **Vue 書いて、メンテナブルな React を生成。**
 
-> Vue→React 移行と混在開発のための完全なソリューション。
+> Vue→React 移行のためのスマートコンパイラ。
 >
-> Vue 3 SFC・Script・Style をランタイムなしで純粋な React へ変換。`<script setup>` ・段階的移行・混在開発に対応。
+> Vue 3 SFC・Script・Style をランタイムブリッジなしで純粋な React に変換。
+> 段階的移行と Vue+React ハイブリッド開発に対応。
 
 [![Npm](https://img.shields.io/npm/v/@vureact/compiler-core.svg?label=Npm&style=flat-square)](https://vureact.top/en/)
 [![Stars](https://img.shields.io/github/stars/vureact-js/core?style=flat-square&logo=github)](https://github.com/vureact-js/core/stargazers)

--- a/README.ja.md
+++ b/README.ja.md
@@ -11,15 +11,13 @@
 > Vue 3 SFC・Script・Style をランタイムブリッジなしで純粋な React に変換。
 > 段階的移行と Vue+React ハイブリッド開発に対応。
 
-[![Npm](https://img.shields.io/npm/v/@vureact/compiler-core.svg?label=Npm&style=flat-square)](https://vureact.top/en/)
-[![Stars](https://img.shields.io/github/stars/vureact-js/core?style=flat-square&logo=github)](https://github.com/vureact-js/core/stargazers)
-[![Downloads](https://img.shields.io/npm/dt/@vureact/compiler-core?label=Downloads&style=flat-square&color=red)](https://www.npmjs.com/package/@vureact/compiler-core)
+[![Npm](https://img.shields.io/npm/v/@vureact/compiler-core.svg?label=Npm&style=flat-square)](https://vureact.top/)
+[![Stars](https://img.shields.io/github/stars/vureact-js/core?color=white&style=flat-square&logo=github)](https://github.com/vureact-js/core/stargazers)
 [![Monthly](https://img.shields.io/npm/dm/@vureact/compiler-core?label=Monthly&style=flat-square)](https://www.npmjs.com/package/@vureact/compiler-core)
+[![Downloads](https://img.shields.io/npm/dt/@vureact/compiler-core?label=Downloads&style=flat-square&color=red)](https://www.npmjs.com/package/@vureact/compiler-core)
 [![Coverage](https://codecov.io/gh/vureact-js/core/graph/badge.svg?flag=compiler-core&style=flat-square)](https://codecov.io/gh/vureact-js/core)
 [![Node](https://img.shields.io/badge/node-%3E%3D20.19.0-green?label=Node)](https://nodejs.org/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://github.com/vureact-js/core/blob/master/LICENSE)
-[![Vue 3](https://img.shields.io/badge/Vue-3.x-42b883)](https://vuejs.org/)
-[![React 18+](https://img.shields.io/badge/React-18%2B-61dafb)](https://reactjs.org/)
 
 [オンラインで試す](#️-オンラインプレイグラウンドインストール不要) · [クイックスタート](#-クイックスタート) · [利用シーン](#-利用シーン) · [エコシステム](#️-エコシステム) · [コンパイル約定](https://vureact.top/en/guide/specification.html) · [比較（セマンティック）](https://vureact.top/en/guide/semantic-comparison/overview.html) · [更新履歴](https://vureact.top/en/guide/changelog.html)
 

--- a/README.ja.md
+++ b/README.ja.md
@@ -11,14 +11,12 @@
 > Vue 3 SFC・Script・Style をランタイムブリッジなしで純粋な React に変換。
 > 段階的移行と Vue+React ハイブリッド開発に対応。
 
-[![Npm](https://img.shields.io/npm/v/@vureact/compiler-core.svg?label=Npm&style=flat-square)](https://vureact.top/)
-[![Stars](https://img.shields.io/github/stars/vureact-js/core?color=white&style=flat-square&logo=github)](https://github.com/vureact-js/core/stargazers)
-[![Monthly](https://img.shields.io/npm/dm/@vureact/compiler-core?label=Monthly&style=flat-square)](https://www.npmjs.com/package/@vureact/compiler-core)
-[![Downloads](https://img.shields.io/npm/dt/@vureact/compiler-core?label=Downloads&style=flat-square&color=red)](https://www.npmjs.com/package/@vureact/compiler-core)
-[![Coverage](https://codecov.io/gh/vureact-js/core/graph/badge.svg?flag=compiler-core&style=flat-square)](https://codecov.io/gh/vureact-js/core)
+[![Npm](https://img.shields.io/npm/v/@vureact/compiler-core.svg?label=Npm)](https://vureact.top/)
+[![Stars](https://img.shields.io/github/stars/vureact-js/core?color=white&logo=github&style=flat-square)](https://github.com/vureact-js/core/stargazers)
+[![Downloads](https://img.shields.io/npm/dt/@vureact/compiler-core?label=Downloads)](https://www.npmjs.com/package/@vureact/compiler-core)
+[![Coverage](https://codecov.io/gh/vureact-js/core/graph/badge.svg?flag=compiler-core)](https://codecov.io/gh/vureact-js/core)
 [![Node](https://img.shields.io/badge/node-%3E%3D20.19.0-green?label=Node)](https://nodejs.org/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://github.com/vureact-js/core/blob/master/LICENSE)
-
 [オンラインで試す](#️-オンラインプレイグラウンドインストール不要) · [クイックスタート](#-クイックスタート) · [利用シーン](#-利用シーン) · [エコシステム](#️-エコシステム) · [コンパイル約定](https://vureact.top/en/guide/specification.html) · [比較（セマンティック）](https://vureact.top/en/guide/semantic-comparison/overview.html) · [更新履歴](https://vureact.top/en/guide/changelog.html)
 
 日本語 | [English](./README.en.md) | [简体中文](./README.md)

--- a/README.md
+++ b/README.md
@@ -6,10 +6,10 @@
 
 **写 Vue，输出可维护的 React。**
 
-> 一套面向 Vue 迁移 React 与混合开发的完整解决方案。
+> 专为 Vue 迁移 React 设计的智能编译器。
 >
-> 将 Vue 3 SFCs・Scripts・Styles 完整转为纯 React（非运行时桥接），
-> 覆盖 `<script setup>` 核心全特性，支持渐进式迁移与混合开发。
+> 将 Vue 3 组件・脚本・样式完整转为纯 React（非运行时桥接），
+> 支持渐进式迁移与 Vue+React 混合开发。
 
 [![Npm](https://img.shields.io/npm/v/@vureact/compiler-core.svg?label=Npm&style=flat-square)](https://vureact.top/)
 [![Stars](https://img.shields.io/github/stars/vureact-js/core?style=flat-square&logo=github)](https://github.com/vureact-js/core/stargazers)

--- a/README.md
+++ b/README.md
@@ -11,11 +11,10 @@
 > 将 Vue 3 组件・脚本・样式完整转为纯 React（非运行时桥接），
 > 支持渐进式迁移与 Vue+React 混合开发。
 
-[![Npm](https://img.shields.io/npm/v/@vureact/compiler-core.svg?label=Npm&style=flat-square)](https://vureact.top/)
-[![Stars](https://img.shields.io/github/stars/vureact-js/core?color=white&style=flat-square&logo=github)](https://github.com/vureact-js/core/stargazers)
-[![Monthly](https://img.shields.io/npm/dm/@vureact/compiler-core?label=Monthly&style=flat-square)](https://www.npmjs.com/package/@vureact/compiler-core)
-[![Downloads](https://img.shields.io/npm/dt/@vureact/compiler-core?label=Downloads&style=flat-square&color=red)](https://www.npmjs.com/package/@vureact/compiler-core)
-[![Coverage](https://codecov.io/gh/vureact-js/core/graph/badge.svg?flag=compiler-core&style=flat-square)](https://codecov.io/gh/vureact-js/core)
+[![Npm](https://img.shields.io/npm/v/@vureact/compiler-core.svg?label=Npm)](https://vureact.top/)
+[![Stars](https://img.shields.io/github/stars/vureact-js/core?color=white&logo=github&style=flat-square)](https://github.com/vureact-js/core/stargazers)
+[![Downloads](https://img.shields.io/npm/dt/@vureact/compiler-core?label=Downloads)](https://www.npmjs.com/package/@vureact/compiler-core)
+[![Coverage](https://codecov.io/gh/vureact-js/core/graph/badge.svg?flag=compiler-core)](https://codecov.io/gh/vureact-js/core)
 [![Node](https://img.shields.io/badge/node-%3E%3D20.19.0-green?label=Node)](https://nodejs.org/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://github.com/vureact-js/core/blob/master/LICENSE)
 

--- a/README.md
+++ b/README.md
@@ -12,14 +12,12 @@
 > 支持渐进式迁移与 Vue+React 混合开发。
 
 [![Npm](https://img.shields.io/npm/v/@vureact/compiler-core.svg?label=Npm&style=flat-square)](https://vureact.top/)
-[![Stars](https://img.shields.io/github/stars/vureact-js/core?style=flat-square&logo=github)](https://github.com/vureact-js/core/stargazers)
-[![Downloads](https://img.shields.io/npm/dt/@vureact/compiler-core?label=Downloads&style=flat-square&color=red)](https://www.npmjs.com/package/@vureact/compiler-core)
+[![Stars](https://img.shields.io/github/stars/vureact-js/core?color=white&style=flat-square&logo=github)](https://github.com/vureact-js/core/stargazers)
 [![Monthly](https://img.shields.io/npm/dm/@vureact/compiler-core?label=Monthly&style=flat-square)](https://www.npmjs.com/package/@vureact/compiler-core)
+[![Downloads](https://img.shields.io/npm/dt/@vureact/compiler-core?label=Downloads&style=flat-square&color=red)](https://www.npmjs.com/package/@vureact/compiler-core)
 [![Coverage](https://codecov.io/gh/vureact-js/core/graph/badge.svg?flag=compiler-core&style=flat-square)](https://codecov.io/gh/vureact-js/core)
 [![Node](https://img.shields.io/badge/node-%3E%3D20.19.0-green?label=Node)](https://nodejs.org/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://github.com/vureact-js/core/blob/master/LICENSE)
-[![Vue 3](https://img.shields.io/badge/Vue-3.x-42b883)](https://vuejs.org/)
-[![React 18+](https://img.shields.io/badge/React-18%2B-61dafb)](https://reactjs.org/)
 
 [在线体验](#️-在线体验无需安装) · [快速开始](#-快速开始) · [适用场景](#-适用场景) · [生态集成](#️-生态集成) · [编译约定](https://vureact.top/guide/specification.html) · [转换对照](https://vureact.top/guide/semantic-comparison/overview.html) · [更新日志](https://vureact.top/guide/changelog.html)
 

--- a/packages/compiler-core/CHANGELOG-zh-CN.md
+++ b/packages/compiler-core/CHANGELOG-zh-CN.md
@@ -4,6 +4,25 @@
 格式基于 [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)，
 并且本项目遵循 [语义化版本](https://semver.org/spec/v2.0.0.html)。
 
+## [1.10.0] - 2026-07-01
+
+### 新增功能
+
+- 新增 `withDefaults` 宏 API 转换支持：将 Vue 3 的 `withDefaults(defineProps<T>(), {...})` 编译为 React 的 `useMemo`，结合对象展开与空值合并运算符，为组件 props 提供安全的默认值处理 [#63](https://github.com/vureact-js/core/issues/63)
+
+### Bug 修复
+
+- 修复使用 `unplugin-auto-import` 等免 import 插件时，Vue API（如 ref、computed、onMounted 等），内部 adapter 因缺少 binding 无法识别 Vue API，导致跳过转换的问题 [#62](https://github.com/vureact-js/core/issues/62)
+
+### 重构与优化
+
+- 新增 `withDefaults` 转换的单元测试覆盖
+- 优化编译流程提示，细分为 3 个阶段：将 `Compiling Vue to React...` 改为 `Compiling components/scripts/styles...`
+
+[1.10.0]: https://github.com/vureact-js/core/compare/v1.9.0...v1.10.0
+
+---
+
 ## [1.9.0] - 2026-06-23
 
 ### 新增功能
@@ -682,8 +701,9 @@ compiler-core/
 
 ---
 
-```text
-[Unreleased]: https://github.com/vureact-js/core/compare/v1.9.0...HEAD
+```log
+[Unreleased]: https://github.com/vureact-js/core/compare/v1.10.0...HEAD
+[1.10.0]: https://github.com/vureact-js/core/compare/v1.9.0...v1.10.0
 [1.9.0]: https://github.com/vureact-js/core/compare/v1.8.5...v1.9.0
 [1.8.5]: https://github.com/vureact-js/core/compare/v1.8.4...v1.8.5
 [1.8.4]: https://github.com/vureact-js/core/compare/v1.8.3...v1.8.4

--- a/packages/compiler-core/CHANGELOG.md
+++ b/packages/compiler-core/CHANGELOG.md
@@ -5,6 +5,25 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.10.0] - 2026-07-01
+
+### Added
+
+- Added `withDefaults` macro API transform support: compiles Vue 3's `withDefaults(defineProps<T>(), {...})` into React's `useMemo`, combining object spread and nullish coalescing operator to provide safe default value handling for component props [#63](https://github.com/vureact-js/core/issues/63)
+
+### Fixed
+
+- Fixed an issue where Vue APIs (e.g., `ref`, `computed`, `onMounted`, etc.) were not recognized by the internal adapter due to missing bindings when using import-free plugins such as `unplugin-auto-import`, causing the transformation to be skipped [#62](https://github.com/vureact-js/core/issues/62)
+
+### Changed
+
+- Added unit test coverage for `withDefaults` transform
+- Optimized compilation flow prompts, subdivided into 3 phases: changed `Compiling Vue to React...` to `Compiling components/scripts/styles...`
+
+[1.10.0]: https://github.com/vureact-js/core/compare/v1.9.0...v1.10.0
+
+---
+
 ## [1.9.0] - 2026-06-23
 
 ### Added
@@ -683,8 +702,9 @@ When releasing a new version:
 
 ---
 
-```text
-[Unreleased]: https://github.com/vureact-js/core/compare/v1.9.0...HEAD
+```log
+[Unreleased]: https://github.com/vureact-js/core/compare/v1.10.0...HEAD
+[1.10.0]: https://github.com/vureact-js/core/compare/v1.9.0...v1.10.0
 [1.9.0]: https://github.com/vureact-js/core/compare/v1.8.5...v1.9.0
 [1.8.5]: https://github.com/vureact-js/core/compare/v1.8.4...v1.8.5
 [1.8.4]: https://github.com/vureact-js/core/compare/v1.8.3...v1.8.4

--- a/packages/compiler-core/README.md
+++ b/packages/compiler-core/README.md
@@ -1,11 +1,10 @@
 # @vureact/compiler-core
 
-`@vureact/compiler-core` is a complete solution for Vue-to-React migration and hybrid development. **CLI and core compiler package** of VuReact.  
-For Vue-to-React migration and hybrid development
-It is used to fully convert Vue 3 SFCs, Scripts, and Styles into pure React (non-runtime bridge) code and output engineered artifacts, covering all core features of `<script setup>`, and supporting progressive migration and hybrid development.
+`@vureact/compiler-core` is a smart compiler built for migrating Vue to React — the **CLI and core compiler package** of VuReact.
+It fully converts Vue 3 single-file components, scripts, and styles into pure React code (no runtime bridge), outputting production-ready artifacts.
+It covers all core features of `<script setup>`, supporting progressive migration and Vue+React hybrid development.
 
 [![Npm](https://img.shields.io/npm/v/@vureact/compiler-core.svg?label=Npm&style=flat-square)](https://vureact.top/)
-[![Stars](https://img.shields.io/github/stars/vureact-js/core?style=flat-square&logo=github)](https://github.com/vureact-js/core/stargazers)
 [![Downloads](https://img.shields.io/npm/dt/@vureact/compiler-core?label=Downloads&style=flat-square)](https://www.npmjs.com/package/@vureact/compiler-core)
 [![Coverage](https://codecov.io/gh/vureact-js/core/graph/badge.svg?flag=compiler-core&style=flat-square)](https://codecov.io/gh/vureact-js/core)
 [![Node](https://img.shields.io/badge/node-%3E%3D20.19.0-green?label=Node)](https://nodejs.org/)

--- a/packages/compiler-core/README.zh-CN.md
+++ b/packages/compiler-core/README.zh-CN.md
@@ -1,10 +1,9 @@
 # @vureact/compiler-core
 
-`@vureact/compiler-core` 是一套面向 Vue 迁移 React 和混合开发的完整解决方案。VuReact 的 **CLI 与核心编译包**。  
-它用于将 Vue 3 SFCs・Scripts・Styles 完整转为纯 React（非运行时桥接）代码并输出工程化产物，覆盖 `<script setup>` 核心全特性，支持渐进式迁移和混合开发。
+`@vureact/compiler-core` 是专为 Vue 迁移 React 设计的智能编译器，也是 VuReact 的 **CLI 与核心编译包**。
+它用于将 Vue 3 单文件组件・脚本・样式完整转为纯 React（非运行时桥接）代码并输出工程化产物，覆盖 `<script setup>` 核心全特性，支持渐进式迁移与 Vue+React 混合开发。
 
 [![Npm](https://img.shields.io/npm/v/@vureact/compiler-core.svg?label=Npm&style=flat-square)](https://vureact.top/)
-[![Stars](https://img.shields.io/github/stars/vureact-js/core?style=flat-square&logo=github)](https://github.com/vureact-js/core/stargazers)
 [![Downloads](https://img.shields.io/npm/dt/@vureact/compiler-core?label=Downloads&style=flat-square)](https://www.npmjs.com/package/@vureact/compiler-core)
 [![Coverage](https://codecov.io/gh/vureact-js/core/graph/badge.svg?flag=compiler-core&style=flat-square)](https://codecov.io/gh/vureact-js/core)
 [![Node](https://img.shields.io/badge/node-%3E%3D20.19.0-green?label=Node)](https://nodejs.org/)

--- a/packages/compiler-core/package.json
+++ b/packages/compiler-core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@vureact/compiler-core",
-  "version": "1.9.0",
-  "description": "For Vue-to-React migration and hybrid development.",
+  "version": "1.10.0",
+  "description": "A smart compiler for migrating Vue to React",
   "author": "Ruihong Zhong (Ryan John)",
   "license": "MIT",
   "type": "module",

--- a/packages/compiler-core/package.json
+++ b/packages/compiler-core/package.json
@@ -48,7 +48,7 @@
     "automated-refactoring",
     "cross-framework"
   ],
-  "homepage": "https://github.com/vureact-js/core#readme",
+  "homepage": "https://vureact.top/en",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/vureact-js/core.git",

--- a/packages/compiler-core/src/__tests__/core/resolve-with-defaults.test.ts
+++ b/packages/compiler-core/src/__tests__/core/resolve-with-defaults.test.ts
@@ -1,0 +1,463 @@
+import { parse } from '@babel/parser';
+import traverse from '@babel/traverse';
+import * as t from '@babel/types';
+import { ICompilationContext } from '@compiler/context/types';
+import { resolveWithDefaults } from '@core/transform/sfc/script/syntax-processor/postprocess/resolve-with-defaults';
+import { resolveWithDefaultsOptions } from '@core/transform/sfc/script/syntax-processor/preprocess/resolve-with-defaults';
+
+function createMockCtx(overrides?: Partial<ICompilationContext>): ICompilationContext {
+  return {
+    inputType: 'sfc',
+    propField: 'props',
+    fileId: 'test',
+    source: '',
+    filename: 'test.vue',
+    imports: new Map(),
+    cssVars: [],
+    templateData: {
+      slots: {},
+      refBindings: { domRefs: {}, componentRefs: {} },
+      reactiveBindings: {},
+      declaredProps: new Set(),
+      declaredEmits: new Set(),
+    },
+    scriptData: {
+      lang: 'ts',
+      source: '',
+      propsTSIface: { name: '', propsTypes: [], emitTypes: [], slotTypes: [] },
+      provide: { name: '', value: '', isOccupied: false, provide: {} },
+      forwardRef: { enabled: false, refField: 'expose' },
+      declaredOptions: {},
+      __vureact_script_block_ir: { exports: [] },
+    },
+    styleData: { filePath: '' },
+    ...overrides,
+  };
+}
+
+function runPreprocess(
+  code: string,
+  ctx: ICompilationContext,
+): { ast: t.File; ctx: ICompilationContext } {
+  const ast = parse(code, {
+    sourceType: 'module',
+    plugins: ['typescript'],
+  }) as unknown as t.File;
+
+  const visitor = resolveWithDefaultsOptions(ctx, ast as any);
+
+  traverse(ast, visitor);
+
+  return { ast, ctx };
+}
+
+function runPostprocess(ast: t.File, ctx: ICompilationContext) {
+  const visitor = resolveWithDefaults(ctx);
+  traverse(ast, visitor);
+}
+
+function runFullTransform(
+  code: string,
+  ctx?: ICompilationContext,
+): { ast: t.File; ctx: ICompilationContext } {
+  const fullCtx = ctx || createMockCtx();
+  const { ast } = runPreprocess(code, fullCtx);
+  runPostprocess(ast, fullCtx);
+  return { ast, ctx: fullCtx };
+}
+
+describe('resolveWithDefaultsOptions (preprocess)', () => {
+  beforeEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  test('ignores non-withDefaults calls', () => {
+    const code = 'const props = defineProps<{ msg?: string }>();';
+    const ctx = createMockCtx();
+    runPreprocess(code, ctx);
+
+    expect(ctx.scriptData.propsWithDefaults).toBeUndefined();
+    expect(ctx.propField).toBe('props');
+  });
+
+  test('logs error when withDefaults is not assigned to a variable', () => {
+    const code = 'withDefaults(defineProps<{ msg?: string }>(), { msg: "hello" });';
+    const ctx = createMockCtx();
+    const spy = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+    runPreprocess(code, ctx);
+
+    expect(ctx.scriptData.propsWithDefaults).toBeUndefined();
+    spy.mockRestore();
+  });
+
+  test('logs error when no arguments provided', () => {
+    const spy = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+    const code = `const props = withDefaults();`;
+    const ctx = createMockCtx();
+    runPreprocess(code, ctx);
+
+    expect(ctx.scriptData.propsWithDefaults).toBeUndefined();
+    spy.mockRestore();
+  });
+
+  test('logs error when first argument is not defineProps call', () => {
+    const code = `const props = withDefaults('hello', { msg: 'hello' });`;
+    const ctx = createMockCtx();
+    const spy = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+    runPreprocess(code, ctx);
+
+    expect(ctx.scriptData.propsWithDefaults).toBeUndefined();
+    spy.mockRestore();
+  });
+
+  test('logs error when second argument is not an object literal', () => {
+    const code = `const props = withDefaults(defineProps<{ msg?: string }>(), someVar);`;
+    const ctx = createMockCtx();
+    const spy = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+    runPreprocess(code, ctx);
+
+    expect(ctx.scriptData.propsWithDefaults).toBeUndefined();
+    spy.mockRestore();
+  });
+
+  test('records propsWithDefaults and inserts placeholder', () => {
+    const code = `const props = withDefaults(defineProps<{ msg?: string; count?: number }>(), {
+      msg: 'hello',
+      count: 42,
+    });`;
+
+    const ctx = createMockCtx();
+    const { ast } = runPreprocess(code, ctx);
+
+    // 检查上下文是否记录了正确的信息
+    expect(ctx.scriptData.propsWithDefaults).toBeDefined();
+    expect(ctx.scriptData.propsWithDefaults!.varName).toBe('props');
+    expect(ctx.scriptData.propsWithDefaults!.values).toBeDefined();
+    expect(ctx.scriptData.propsWithDefaults!.start).toBeDefined();
+    expect(ctx.scriptData.propsWithDefaults!.end).toBeDefined();
+
+    // 检查 propField 已被重命名
+    expect(ctx.propField).toBe('vrProps');
+
+    // 检查占位符是否被插入到 AST 中
+    let hasPlaceholder = false;
+    traverse(ast, {
+      EmptyStatement(path) {
+        if (
+          path.node.leadingComments?.some(
+            (c) => c.type === 'CommentBlock' && c.value.includes('from withDefaults'),
+          )
+        ) {
+          hasPlaceholder = true;
+        }
+      },
+    });
+    expect(hasPlaceholder).toBe(true);
+
+    // 检查 withDefaults 是否被替换为 defineProps
+    let definePropsCall: t.CallExpression | undefined;
+    traverse(ast, {
+      CallExpression(path) {
+        if (t.isIdentifier(path.node.callee) && path.node.callee.name === 'defineProps') {
+          definePropsCall = path.node;
+        }
+      },
+    });
+    expect(definePropsCall).toBeDefined();
+  });
+
+  test('flattens function-wrapped default values', () => {
+    const code = `const props = withDefaults(defineProps<{ labels: string[] }>(), {
+      labels: () => ['one', 'two'],
+    });`;
+
+    const ctx = createMockCtx();
+    runPreprocess(code, ctx);
+
+    const values = ctx.scriptData.propsWithDefaults!.values as t.ObjectExpression;
+    const labelsProp = values.properties[0] as t.ObjectProperty;
+
+    // 函数包装已被展开，labels 的值应该是数组字面量，而不是箭头函数
+    expect(t.isArrayExpression(labelsProp.value)).toBe(true);
+    const arr = labelsProp.value as t.ArrayExpression;
+    expect(arr.elements.map((e) => (e as t.StringLiteral).value)).toEqual(['one', 'two']);
+  });
+
+  test('preserves non-function-wrapped default values as-is', () => {
+    const code = `const props = withDefaults(defineProps<{ msg?: string; count?: number }>(), {
+      msg: 'hello',
+      count: 42,
+    });`;
+
+    const ctx = createMockCtx();
+    runPreprocess(code, ctx);
+
+    const values = ctx.scriptData.propsWithDefaults!.values as t.ObjectExpression;
+
+    const msgProp = values.properties[0] as t.ObjectProperty;
+    expect(t.isStringLiteral(msgProp.value)).toBe(true);
+    expect((msgProp.value as t.StringLiteral).value).toBe('hello');
+
+    const countProp = values.properties[1] as t.ObjectProperty;
+    expect(t.isNumericLiteral(countProp.value)).toBe(true);
+    expect((countProp.value as t.NumericLiteral).value).toBe(42);
+  });
+});
+
+describe('resolveWithDefaults (postprocess)', () => {
+  test('replaces placeholder with useMemo variable declaration', () => {
+    const code = `const props = withDefaults(defineProps<{ msg?: string; count?: number }>(), {
+      msg: 'hello',
+      count: 42,
+    });`;
+
+    const ctx = createMockCtx();
+    const { ast } = runFullTransform(code, ctx);
+
+    // 检查 useMemo 是否被插入
+    let useMemoCall: t.CallExpression | undefined;
+    traverse(ast, {
+      CallExpression(path) {
+        if (t.isIdentifier(path.node.callee) && path.node.callee.name === 'useMemo') {
+          useMemoCall = path.node;
+        }
+      },
+    });
+
+    expect(useMemoCall).toBeDefined();
+
+    // 检查是否有 useMemo 的导入记录
+    const reactImports = ctx.imports.get('react');
+    expect(reactImports).toBeDefined();
+    expect(reactImports!.some((i) => i.name === 'useMemo')).toBe(true);
+  });
+
+  test('generates correct useMemo structure', () => {
+    const code = `const props = withDefaults(defineProps<{ msg?: string; count?: number }>(), {
+      msg: 'hello',
+      count: 42,
+    });`;
+
+    const ctx = createMockCtx();
+    const { ast } = runFullTransform(code, ctx);
+
+    let useMemoCall: t.CallExpression | undefined;
+    traverse(ast, {
+      CallExpression(path) {
+        if (t.isIdentifier(path.node.callee) && path.node.callee.name === 'useMemo') {
+          useMemoCall = path.node;
+        }
+      },
+    });
+
+    expect(useMemoCall).toBeDefined();
+
+    // 检查参数
+    const [arrowFn, deps] = useMemoCall!.arguments;
+
+    // 第一个参数应该是箭头函数
+    expect(t.isArrowFunctionExpression(arrowFn)).toBe(true);
+
+    // 箭头函数体应该是一个对象表达式
+    const body = (arrowFn as t.ArrowFunctionExpression).body;
+    expect(t.isObjectExpression(body)).toBe(true);
+
+    const obj = body as t.ObjectExpression;
+
+    // 第一个成员应该是 spread element：...vrProps
+    expect(t.isSpreadElement(obj.properties[0])).toBe(true);
+
+    // 后续成员应该是默认值合并
+    const msgProp = obj.properties[1] as t.ObjectProperty;
+    expect(
+      t.isIdentifier(msgProp.key)
+        ? (msgProp.key as t.Identifier).name
+        : (msgProp.key as t.StringLiteral).value,
+    ).toBe('msg');
+    expect(t.isLogicalExpression(msgProp.value)).toBe(true);
+
+    // 第二个参数应该是依赖数组 [vrProps]
+    expect(t.isArrayExpression(deps)).toBe(true);
+    const depsArray = deps as t.ArrayExpression;
+    expect(depsArray.elements.length).toBe(1);
+    expect((depsArray.elements[0] as t.Identifier).name).toBe('vrProps');
+  });
+
+  test('uses correct variable name from withDefaults', () => {
+    const code = `const myProps = withDefaults(defineProps<{ msg?: string }>(), {
+      msg: 'hello',
+    });`;
+
+    const ctx = createMockCtx();
+    const { ast } = runFullTransform(code, ctx);
+
+    let varDecl: t.VariableDeclaration | undefined;
+    traverse(ast, {
+      VariableDeclaration(path) {
+        const decl = path.node.declarations[0];
+        if (decl && t.isIdentifier(decl.id) && decl.id.name === 'myProps') {
+          varDecl = path.node;
+        }
+      },
+    });
+
+    expect(varDecl).toBeDefined();
+    expect(varDecl!.declarations.length).toBe(1);
+    expect((varDecl!.declarations[0]?.init as t.CallExpression).callee).toBeDefined();
+  });
+
+  test('preserves type parameters on useMemo', () => {
+    const code = `const props = withDefaults(defineProps<{ msg?: string }>(), {
+      msg: 'hello',
+    });`;
+
+    const ctx = createMockCtx();
+    const { ast } = runFullTransform(code, ctx);
+
+    let useMemoCall: t.CallExpression | undefined;
+    traverse(ast, {
+      CallExpression(path) {
+        if (t.isIdentifier(path.node.callee) && path.node.callee.name === 'useMemo') {
+          useMemoCall = path.node;
+        }
+      },
+    });
+
+    expect(useMemoCall).toBeDefined();
+    // Type parameters should be preserved for TS
+    expect(useMemoCall!.typeParameters).toBeDefined();
+  });
+
+  test('handles non-TS input', () => {
+    const code = `const props = withDefaults(defineProps({ msg: String, count: Number }), {
+      msg: 'hello',
+      count: 42,
+    });`;
+
+    const ctx = createMockCtx({
+      scriptData: {
+        lang: 'js',
+        source: '',
+        propsTSIface: { name: '', propsTypes: [], emitTypes: [], slotTypes: [] },
+        provide: { name: '', value: '', isOccupied: false, provide: {} },
+        forwardRef: { enabled: false, refField: 'expose' },
+        declaredOptions: {},
+        __vureact_script_block_ir: { exports: [] },
+      },
+    });
+
+    const { ast } = runFullTransform(code, ctx);
+
+    let useMemoCall: t.CallExpression | undefined;
+    traverse(ast, {
+      CallExpression(path) {
+        if (t.isIdentifier(path.node.callee) && path.node.callee.name === 'useMemo') {
+          useMemoCall = path.node;
+        }
+      },
+    });
+
+    // In JS mode, the postprocess should still generate useMemo
+    expect(useMemoCall).toBeDefined();
+    // No type parameters in JS mode (undefined, not null)
+    expect(useMemoCall!.typeParameters).toBeUndefined();
+  });
+
+  test('does nothing when no withDefaults used', () => {
+    const code = `const msg = 'hello';`;
+    const ctx = createMockCtx();
+    const { ast } = runFullTransform(code, ctx);
+
+    let useMemoCallCount = 0;
+    traverse(ast, {
+      CallExpression(path) {
+        if (t.isIdentifier(path.node.callee) && path.node.callee.name === 'useMemo') {
+          useMemoCallCount++;
+        }
+      },
+    });
+
+    expect(useMemoCallCount).toBe(0);
+    expect(ctx.scriptData.propsWithDefaults).toBeUndefined();
+  });
+
+  test('does nothing for non-SFC input', () => {
+    const code = `const props = withDefaults(defineProps<{ msg?: string }>(), { msg: 'hello' });`;
+    const ctx = createMockCtx({ inputType: 'script-ts' });
+    const { ast } = runFullTransform(code, ctx);
+
+    let useMemoCallCount = 0;
+    traverse(ast, {
+      CallExpression(path) {
+        if (t.isIdentifier(path.node.callee) && path.node.callee.name === 'useMemo') {
+          useMemoCallCount++;
+        }
+      },
+    });
+
+    expect(useMemoCallCount).toBe(0);
+  });
+
+  test('handles function-wrapped default values correctly', () => {
+    const code = `const props = withDefaults(defineProps<{ labels: string[]; fn: () => number }>(), {
+      labels: () => ['one', 'two'],
+      fn: () => 42,
+    });`;
+
+    const ctx = createMockCtx();
+    const { ast } = runFullTransform(code, ctx);
+
+    let useMemoCall: t.CallExpression | undefined;
+    traverse(ast, {
+      CallExpression(path) {
+        if (t.isIdentifier(path.node.callee) && path.node.callee.name === 'useMemo') {
+          useMemoCall = path.node;
+        }
+      },
+    });
+
+    expect(useMemoCall).toBeDefined();
+
+    const arrowFn = useMemoCall!.arguments[0] as t.ArrowFunctionExpression;
+    const obj = arrowFn.body as t.ObjectExpression;
+
+    // labels 应该是数组字面量而不是箭头函数
+    // properties: [SpreadElement(vrProps), labels, fn]
+    const labelsProp = obj.properties[1] as t.ObjectProperty;
+    const keyName = t.isIdentifier(labelsProp.key) ? (labelsProp.key as t.Identifier).name : '';
+    expect(keyName).toBe('labels');
+    const logicalExpr = labelsProp.value as t.LogicalExpression;
+    expect(t.isArrayExpression(logicalExpr.right)).toBe(true);
+    const arr = logicalExpr.right as t.ArrayExpression;
+    expect((arr.elements[0] as t.StringLiteral).value).toBe('one');
+    expect((arr.elements[1] as t.StringLiteral).value).toBe('two');
+  });
+
+  test('preserves leading comments from placeholder', () => {
+    const code = `// some comment
+const props = withDefaults(defineProps<{ msg?: string }>(), {
+  msg: 'hello',
+});`;
+
+    const ctx = createMockCtx();
+    const { ast } = runFullTransform(code, ctx);
+
+    let varDecl: t.VariableDeclaration | undefined;
+    traverse(ast, {
+      VariableDeclaration(path) {
+        const decl = path.node.declarations[0];
+        if (decl && t.isIdentifier(decl.id) && decl.id.name === 'props') {
+          varDecl = path.node;
+        }
+      },
+    });
+
+    expect(varDecl).toBeDefined();
+    expect(varDecl!.leadingComments).toBeDefined();
+    expect(varDecl!.leadingComments!.some((c) => c.value.includes('from withDefaults'))).toBe(true);
+  });
+});

--- a/packages/compiler-core/src/compiler/context/types.ts
+++ b/packages/compiler-core/src/compiler/context/types.ts
@@ -1,4 +1,5 @@
 import * as t from '@babel/types';
+import { SourceLocation } from '@babel/types';
 import { LangType } from '@shared/babel-utils';
 import { ReactiveTypes } from '@shared/reactive-utils';
 
@@ -82,6 +83,9 @@ export interface ICompilationContext {
       inheritAttrs?: boolean;
     };
 
+    /** withDefaults 中的默认值 */
+    propsWithDefaults?: PropsWithDefaults;
+
     /**
      * 使用时手动类型断言为 `ScriptBlockIR`
      */
@@ -152,4 +156,20 @@ export interface IPropsContext {
   propsTypes: t.TSType[];
   emitTypes: t.TSType[];
   slotTypes: t.TSType[];
+}
+
+export interface PropsWithDefaults {
+  varName: string;
+  values: t.Expression | undefined;
+
+  /** 收集 defineProps 的类型参数 */
+  typeParameters?: t.TSTypeParameterInstantiation | null;
+
+  /** 原 withDefaults 调用的 babel 位置信息，用于 postprocess 阶段定位替换 */
+  leadingComments?: t.Comment[] | null;
+  innerComments?: t.Comment[] | null;
+  trailingComments?: t.Comment[] | null;
+  start?: number | null;
+  end?: number | null;
+  loc?: SourceLocation | null;
 }

--- a/packages/compiler-core/src/compiler/shared/file-compiler/index.ts
+++ b/packages/compiler-core/src/compiler/shared/file-compiler/index.ts
@@ -80,9 +80,13 @@ export class FileCompiler extends BaseCompiler {
       this.updateSpinner('Scanning files...');
       const scanFiles = fileProcessor.scanFiles();
 
-      this.updateSpinner('Compiling Vue to React...');
+      this.updateSpinner('Compiling components...');
       const sfcCount = await pipelineManager.runSFC(scanFiles.vue, cacheMap);
+
+      this.updateSpinner('Compiling scripts...');
       const scriptCount = await pipelineManager.runScript(scanFiles.script, cacheMap);
+
+      this.updateSpinner('Compiling styles...');
       const styleCount = await pipelineManager.runStyle(scanFiles.style, cacheMap);
 
       this.updateSpinner('Copying assets...');
@@ -179,7 +183,7 @@ export class FileCompiler extends BaseCompiler {
     styleCount: number,
     assetCount: number,
   ) {
-    this.spinner.succeed(`Build completed in ${endTime}`);
+    this.spinner.succeed(`Vue compiled to React in ${endTime}`);
 
     if (sfcCount || scriptCount || styleCount || assetCount) {
       const stats = [];

--- a/packages/compiler-core/src/consts/adapters-map.ts
+++ b/packages/compiler-core/src/consts/adapters-map.ts
@@ -340,3 +340,12 @@ export const ADAPTER_RULES: AdapterRulesMap = {
     },
   },
 } as const;
+
+// 用于编译器识别哪些 API 来源于免 import，避免转换失败。
+// 排除：dir.* 系
+// （API 名称集合来源于 ADAPTER_RULES）
+export const AUTO_IMPORTED_APIS = new Set<string>(
+  Object.entries(ADAPTER_RULES).flatMap(([_, rules]) =>
+    Object.keys(rules).filter((key) => !key.startsWith('dir')),
+  ),
+);

--- a/packages/compiler-core/src/consts/other.ts
+++ b/packages/compiler-core/src/consts/other.ts
@@ -26,6 +26,7 @@ export const MACRO_API_NAMES = {
   options: 'defineOptions',
   expose: 'defineExpose',
   model: 'defineModel',
+  defaults: 'withDefaults',
 };
 
 /** Vue3 最常用、最核心的 $ 标识符 */

--- a/packages/compiler-core/src/core/parse/sfc/postprocess/resolve-script-metadata/resolve-var-bindings/resolve-reactive-bindings.ts
+++ b/packages/compiler-core/src/core/parse/sfc/postprocess/resolve-script-metadata/resolve-var-bindings/resolve-reactive-bindings.ts
@@ -30,8 +30,8 @@ export function resolveReactiveBindings(node: t.VariableDeclarator, ctx: ICompil
     reactiveType: getReactiveType(callName),
   };
 
-  // 收集 definProps 的变量名作为组件 props 名
-  if (callName === MACRO_API_NAMES.props) {
+  // 收集 definProps/withDefaults 的变量名作为组件 props 名
+  if (callName === MACRO_API_NAMES.props || callName === MACRO_API_NAMES.defaults) {
     ctx.propField = varName;
   }
 }

--- a/packages/compiler-core/src/core/transform/__tests__/api-transform/expected/output.jsx
+++ b/packages/compiler-core/src/core/transform/__tests__/api-transform/expected/output.jsx
@@ -1,11 +1,11 @@
 import { memo } from 'react';
 import { useVRef, useReactive, useComputed, useWatch, useBeforeMount, Provider, useUpdated, useWatchEffect } from '@vureact/runtime-core';
 const Input = memo(() => {
-  const count = useVRef(1);
+  const count = useVRef(2);
   const state = useReactive({
-    count: 1
+    count: 2
   });
-  const result = useComputed(() => count.value + state.count);
+  const result = useComputed(() => (count.value + state.count) * 0.5);
   const r = useVRef;
   useReactive;
   useReactive({

--- a/packages/compiler-core/src/core/transform/__tests__/api-transform/input.vue
+++ b/packages/compiler-core/src/core/transform/__tests__/api-transform/input.vue
@@ -1,18 +1,9 @@
 <script setup>
-import {
-  computed,
-  onBeforeMount,
-  onUpdated,
-  provide,
-  reactive,
-  ref,
-  watch,
-  watchEffect,
-} from 'vue';
+import { onBeforeMount, onUpdated, provide, watchEffect } from 'vue';
 
-const count = ref(1);
-const state = reactive({ count: 1 });
-const result = computed(() => count.value + state.count);
+const count = ref(2);
+const state = reactive({ count: 2 });
+const result = computed(() => (count.value + state.count) * 0.5);
 
 const r = ref;
 

--- a/packages/compiler-core/src/core/transform/__tests__/v-if/expected/output.css
+++ b/packages/compiler-core/src/core/transform/__tests__/v-if/expected/output.css
@@ -1,0 +1,26 @@
+section[data-css-21c4253e] {
+  margin: 16px 0;
+  padding: 12px;
+  border: 1px solid #e0e0e0;
+  border-radius: 8px;
+}
+
+button[data-css-21c4253e],
+a[data-css-21c4253e] {
+  margin-left: 8px;
+  padding: 4px 12px;
+  background: #42b883;
+  color: white;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+a[data-css-21c4253e] {
+  display: inline-block;
+  text-decoration: none;
+}
+
+ul[data-css-21c4253e] {
+  padding-left: 20px;
+}

--- a/packages/compiler-core/src/core/transform/__tests__/v-if/expected/output.jsx
+++ b/packages/compiler-core/src/core/transform/__tests__/v-if/expected/output.jsx
@@ -32,24 +32,20 @@ const Input = memo(() => {
     }, 1000);
   }
 
-// 示例 7：可选链 ?.
-const data = useVRef(null);
-// 模拟异步获取数据
-setTimeout(() => {
-  data.value = {
-    list: [
-      {
-        name: '张三',
-      },
-      {
-        name: null,
-      },
-      {
-        name: '李四',
-      },
-    ],
-  };
-}, 2000);
+  // 示例 7：可选链 ?.
+  const data = useVRef(null);
+  // 模拟异步获取数据
+  setTimeout(() => {
+    data.value = {
+      list: [{
+        name: '张三'
+      }, {
+        name: null
+      }, {
+        name: '李四'
+      }]
+    };
+  }, 2000);
 
   // 示例 8：深层嵌套可选链
   const user = useVRef({
@@ -57,133 +53,10 @@ setTimeout(() => {
     profile: {
       address: {
         city: '北京',
-        country: '中国',
-      },
-    },
+        country: '中国'
+      }
+    }
   });
-  return (
-    <>
-      {/* ==================== 示例 1：基本 v-if ==================== */}
-      {showTitle.value ? <h1 data-css-21c4253e>Hello Vue</h1> : null}
-      {/* ==================== 示例 2：v-if / v-else ==================== */}
-      {isLoggedIn.value ? (
-        <p data-css-21c4253e>欢迎回来，用户！</p>
-      ) : (
-        <p data-css-21c4253e>请先登录。</p>
-      )}
-      {/* ==================== 示例 3：v-if / v-else-if / v-else ==================== */}
-      {type.value === 'A' ? (
-        <div data-css-21c4253e>类型 A</div>
-      ) : type.value === 'B' ? (
-        <div data-css-21c4253e>类型 B</div>
-      ) : type.value === 'C' ? (
-        <div data-css-21c4253e>类型 C</div>
-      ) : (
-        <div data-css-21c4253e>未知类型</div>
-      )}
-      {/* ==================== 示例 4：在 template 上使用 v-if 分组 ==================== */}
-      {hasPermission.value ? (
-        <>
-          <h2 data-css-21c4253e>管理员面板</h2>
-          <p data-css-21c4253e>你拥有管理员权限。</p>
-          <button data-css-21c4253e>管理用户</button>
-        </>
-      ) : (
-        <>
-          <h2 data-css-21c4253e>普通用户面板</h2>
-          <p data-css-21c4253e>功能受限。</p>
-        </>
-      )}
-      {/* ==================== 示例 5：复杂条件（结合 computed） ==================== */}
-      <section data-css-21c4253e>
-        {isVIP.value ? (
-          <div data-css-21c4253e>
-            <span data-css-21c4253e>🌟 VIP 会员专享内容</span>
-            <ul data-css-21c4253e>
-              <li data-css-21c4253e>高级主题</li>
-              <li data-css-21c4253e>专属客服</li>
-            </ul>
-          </div>
-        ) : isPremium.value ? (
-          <div data-css-21c4253e>
-            <span data-css-21c4253e>💎 高级会员</span>
-          </div>
-        ) : (
-          <div data-css-21c4253e>
-            <span data-css-21c4253e>🔓 免费用户</span>
-            <a href="/upgrade" data-css-21c4253e>
-              升级会员
-            </a>
-          </div>
-        )}
-      </section>
-      {/* ==================== 示例 6：嵌套条件 ==================== */}
-      {status.value === 'loading' ? (
-        <div data-css-21c4253e>
-          <span data-css-21c4253e>⏳ 加载中…</span>
-        </div>
-      ) : status.value === 'error' ? (
-        <div data-css-21c4253e>
-          <span data-css-21c4253e>❌ 加载失败：{errorMessage.value}</span>
-          <button onClick={retry} data-css-21c4253e>
-            重试
-          </button>
-        </div>
-      ) : (
-        <div data-css-21c4253e>
-          {items.value.length === 0 ? (
-            <div data-css-21c4253e>
-              <span data-css-21c4253e>📭 暂无数据</span>
-            </div>
-          ) : (
-            <div data-css-21c4253e>
-              <ul data-css-21c4253e>
-                {items.value.map((item, index) => (
-                  <li key={index} data-css-21c4253e>
-                    {item}
-                  </li>
-                ))}
-              </ul>
-            </div>
-          )}
-        </div>
-      )}
-      {/* ==================== 示例 7：可选链操作符 ?. 安全访问 ==================== */}
-      {data.value?.list ? (
-        <div data-css-21c4253e>
-          <p data-css-21c4253e>data.list 存在且非空，长度为：{data.value.list.length}</p>
-          <ul data-css-21c4253e>
-            {data.value.list.map((item, i) => (
-              <li key={i} data-css-21c4253e>
-                {item?.name ?? '未命名'}
-              </li>
-            ))}
-          </ul>
-        </div>
-      ) : data.value?.list === undefined ? (
-        <div data-css-21c4253e>
-          <p data-css-21c4253e>data 或 data.list 为 undefined（安全访问避免报错）</p>
-        </div>
-      ) : (
-        <div data-css-21c4253e>
-          <p data-css-21c4253e>data.list 存在但为空数组</p>
-        </div>
-      )}
-      {/* ==================== 示例 8：更深层嵌套的可选链 ==================== */}
-      {user.value?.profile?.address?.city ? (
-        <article data-css-21c4253e>
-          <h3 data-css-21c4253e>{user.value?.name}的城市</h3>
-          <p data-css-21c4253e>
-            {user.value?.profile?.address?.city}，{user.value?.profile?.address?.country}
-          </p>
-        </article>
-      ) : (
-        <article data-css-21c4253e>
-          <h3 data-css-21c4253e>{user.value?.name ?? '未知用户'}</h3>
-          <p data-css-21c4253e>地址信息不完整</p>
-        </article>
-      )}
-    </>
-  );
+  return <>{/* ==================== 示例 1：基本 v-if ==================== */}{showTitle.value ? <h1 data-css-21c4253e>Hello Vue</h1> : null}{/* ==================== 示例 2：v-if / v-else ==================== */}{isLoggedIn.value ? <p data-css-21c4253e>欢迎回来，用户！</p> : <p data-css-21c4253e>请先登录。</p>}{/* ==================== 示例 3：v-if / v-else-if / v-else ==================== */}{type.value === 'A' ? <div data-css-21c4253e>类型 A</div> : type.value === 'B' ? <div data-css-21c4253e>类型 B</div> : type.value === 'C' ? <div data-css-21c4253e>类型 C</div> : <div data-css-21c4253e>未知类型</div>}{/* ==================== 示例 4：在 template 上使用 v-if 分组 ==================== */}{hasPermission.value ? <><h2 data-css-21c4253e>管理员面板</h2><p data-css-21c4253e>你拥有管理员权限。</p><button data-css-21c4253e>管理用户</button></> : <><h2 data-css-21c4253e>普通用户面板</h2><p data-css-21c4253e>功能受限。</p></>}{/* ==================== 示例 5：复杂条件（结合 computed） ==================== */}<section data-css-21c4253e>{isVIP.value ? <div data-css-21c4253e><span data-css-21c4253e>🌟 VIP 会员专享内容</span><ul data-css-21c4253e><li data-css-21c4253e>高级主题</li><li data-css-21c4253e>专属客服</li></ul></div> : isPremium.value ? <div data-css-21c4253e><span data-css-21c4253e>💎 高级会员</span></div> : <div data-css-21c4253e><span data-css-21c4253e>🔓 免费用户</span><a href='/upgrade' data-css-21c4253e>升级会员</a></div>}</section>{/* ==================== 示例 6：嵌套条件 ==================== */}{status.value === 'loading' ? <div data-css-21c4253e><span data-css-21c4253e>⏳ 加载中…</span></div> : status.value === 'error' ? <div data-css-21c4253e><span data-css-21c4253e>❌ 加载失败：{errorMessage.value}</span><button onClick={retry} data-css-21c4253e>重试</button></div> : <div data-css-21c4253e>{items.value.length === 0 ? <div data-css-21c4253e><span data-css-21c4253e>📭 暂无数据</span></div> : <div data-css-21c4253e><ul data-css-21c4253e>{items.value.map((item, index) => <li key={index} data-css-21c4253e>{item}</li>)}</ul></div>}</div>}{/* ==================== 示例 7：可选链操作符 ?. 安全访问 ==================== */}{data.value?.list ? <div data-css-21c4253e><p data-css-21c4253e>data.list 存在且非空，长度为：{data.value.list.length}</p><ul data-css-21c4253e>{data.value.list.map((item, i) => <li key={i} data-css-21c4253e>{item?.name ?? '未命名'}</li>)}</ul></div> : data.value?.list === undefined ? <div data-css-21c4253e><p data-css-21c4253e>data 或 data.list 为 undefined（安全访问避免报错）</p></div> : <div data-css-21c4253e><p data-css-21c4253e>data.list 存在但为空数组</p></div>}{/* ==================== 示例 8：更深层嵌套的可选链 ==================== */}{user.value?.profile?.address?.city ? <article data-css-21c4253e><h3 data-css-21c4253e>{user.value?.name}的城市</h3><p data-css-21c4253e>{user.value?.profile?.address?.city}，{user.value?.profile?.address?.country}</p></article> : <article data-css-21c4253e><h3 data-css-21c4253e>{user.value?.name ?? '未知用户'}</h3><p data-css-21c4253e>地址信息不完整</p></article>}</>;
 });
 export default Input;

--- a/packages/compiler-core/src/core/transform/__tests__/v-if/expected/output.jsx
+++ b/packages/compiler-core/src/core/transform/__tests__/v-if/expected/output.jsx
@@ -1,0 +1,189 @@
+import { memo } from 'react';
+import { useVRef, useComputed } from '@vureact/runtime-core';
+import './input-21c4253e.css';
+const Input = memo(() => {
+  // 示例 1
+  const showTitle = useVRef(true);
+
+  // 示例 2
+  const isLoggedIn = useVRef(false);
+
+  // 示例 3
+  const type = useVRef('B');
+
+  // 示例 4
+  const hasPermission = useVRef(true);
+
+  // 示例 5：复杂条件
+  const userLevel = useVRef('free');
+  const isVIP = useComputed(() => userLevel.value === 'vip');
+  const isPremium = useComputed(() => userLevel.value === 'premium');
+
+  // 示例 6：嵌套条件
+  const status = useVRef('success');
+  const errorMessage = useVRef('');
+  const items = useVRef(['苹果', '香蕉', '橘子']);
+  function retry() {
+    status.value = 'loading';
+    // 模拟重新请求
+    setTimeout(() => {
+      status.value = 'success';
+      items.value = ['苹果', '香蕉', '橘子', '葡萄'];
+    }, 1000);
+  }
+
+// 示例 7：可选链 ?.
+const data = useVRef(null);
+// 模拟异步获取数据
+setTimeout(() => {
+  data.value = {
+    list: [
+      {
+        name: '张三',
+      },
+      {
+        name: null,
+      },
+      {
+        name: '李四',
+      },
+    ],
+  };
+}, 2000);
+
+  // 示例 8：深层嵌套可选链
+  const user = useVRef({
+    name: 'Alice',
+    profile: {
+      address: {
+        city: '北京',
+        country: '中国',
+      },
+    },
+  });
+  return (
+    <>
+      {/* ==================== 示例 1：基本 v-if ==================== */}
+      {showTitle.value ? <h1 data-css-21c4253e>Hello Vue</h1> : null}
+      {/* ==================== 示例 2：v-if / v-else ==================== */}
+      {isLoggedIn.value ? (
+        <p data-css-21c4253e>欢迎回来，用户！</p>
+      ) : (
+        <p data-css-21c4253e>请先登录。</p>
+      )}
+      {/* ==================== 示例 3：v-if / v-else-if / v-else ==================== */}
+      {type.value === 'A' ? (
+        <div data-css-21c4253e>类型 A</div>
+      ) : type.value === 'B' ? (
+        <div data-css-21c4253e>类型 B</div>
+      ) : type.value === 'C' ? (
+        <div data-css-21c4253e>类型 C</div>
+      ) : (
+        <div data-css-21c4253e>未知类型</div>
+      )}
+      {/* ==================== 示例 4：在 template 上使用 v-if 分组 ==================== */}
+      {hasPermission.value ? (
+        <>
+          <h2 data-css-21c4253e>管理员面板</h2>
+          <p data-css-21c4253e>你拥有管理员权限。</p>
+          <button data-css-21c4253e>管理用户</button>
+        </>
+      ) : (
+        <>
+          <h2 data-css-21c4253e>普通用户面板</h2>
+          <p data-css-21c4253e>功能受限。</p>
+        </>
+      )}
+      {/* ==================== 示例 5：复杂条件（结合 computed） ==================== */}
+      <section data-css-21c4253e>
+        {isVIP.value ? (
+          <div data-css-21c4253e>
+            <span data-css-21c4253e>🌟 VIP 会员专享内容</span>
+            <ul data-css-21c4253e>
+              <li data-css-21c4253e>高级主题</li>
+              <li data-css-21c4253e>专属客服</li>
+            </ul>
+          </div>
+        ) : isPremium.value ? (
+          <div data-css-21c4253e>
+            <span data-css-21c4253e>💎 高级会员</span>
+          </div>
+        ) : (
+          <div data-css-21c4253e>
+            <span data-css-21c4253e>🔓 免费用户</span>
+            <a href="/upgrade" data-css-21c4253e>
+              升级会员
+            </a>
+          </div>
+        )}
+      </section>
+      {/* ==================== 示例 6：嵌套条件 ==================== */}
+      {status.value === 'loading' ? (
+        <div data-css-21c4253e>
+          <span data-css-21c4253e>⏳ 加载中…</span>
+        </div>
+      ) : status.value === 'error' ? (
+        <div data-css-21c4253e>
+          <span data-css-21c4253e>❌ 加载失败：{errorMessage.value}</span>
+          <button onClick={retry} data-css-21c4253e>
+            重试
+          </button>
+        </div>
+      ) : (
+        <div data-css-21c4253e>
+          {items.value.length === 0 ? (
+            <div data-css-21c4253e>
+              <span data-css-21c4253e>📭 暂无数据</span>
+            </div>
+          ) : (
+            <div data-css-21c4253e>
+              <ul data-css-21c4253e>
+                {items.value.map((item, index) => (
+                  <li key={index} data-css-21c4253e>
+                    {item}
+                  </li>
+                ))}
+              </ul>
+            </div>
+          )}
+        </div>
+      )}
+      {/* ==================== 示例 7：可选链操作符 ?. 安全访问 ==================== */}
+      {data.value?.list ? (
+        <div data-css-21c4253e>
+          <p data-css-21c4253e>data.list 存在且非空，长度为：{data.value.list.length}</p>
+          <ul data-css-21c4253e>
+            {data.value.list.map((item, i) => (
+              <li key={i} data-css-21c4253e>
+                {item?.name ?? '未命名'}
+              </li>
+            ))}
+          </ul>
+        </div>
+      ) : data.value?.list === undefined ? (
+        <div data-css-21c4253e>
+          <p data-css-21c4253e>data 或 data.list 为 undefined（安全访问避免报错）</p>
+        </div>
+      ) : (
+        <div data-css-21c4253e>
+          <p data-css-21c4253e>data.list 存在但为空数组</p>
+        </div>
+      )}
+      {/* ==================== 示例 8：更深层嵌套的可选链 ==================== */}
+      {user.value?.profile?.address?.city ? (
+        <article data-css-21c4253e>
+          <h3 data-css-21c4253e>{user.value?.name}的城市</h3>
+          <p data-css-21c4253e>
+            {user.value?.profile?.address?.city}，{user.value?.profile?.address?.country}
+          </p>
+        </article>
+      ) : (
+        <article data-css-21c4253e>
+          <h3 data-css-21c4253e>{user.value?.name ?? '未知用户'}</h3>
+          <p data-css-21c4253e>地址信息不完整</p>
+        </article>
+      )}
+    </>
+  );
+});
+export default Input;

--- a/packages/compiler-core/src/core/transform/__tests__/v-if/input.vue
+++ b/packages/compiler-core/src/core/transform/__tests__/v-if/input.vue
@@ -1,0 +1,170 @@
+<template>
+  <!-- ==================== 示例 1：基本 v-if ==================== -->
+  <h1 v-if="showTitle">Hello Vue</h1>
+
+  <!-- ==================== 示例 2：v-if / v-else ==================== -->
+  <p v-if="isLoggedIn">欢迎回来，用户！</p>
+  <p v-else>请先登录。</p>
+
+  <!-- ==================== 示例 3：v-if / v-else-if / v-else ==================== -->
+  <div v-if="type === 'A'">类型 A</div>
+  <div v-else-if="type === 'B'">类型 B</div>
+  <div v-else-if="type === 'C'">类型 C</div>
+  <div v-else>未知类型</div>
+
+  <!-- ==================== 示例 4：在 template 上使用 v-if 分组 ==================== -->
+  <template v-if="hasPermission">
+    <h2>管理员面板</h2>
+    <p>你拥有管理员权限。</p>
+    <button>管理用户</button>
+  </template>
+  <template v-else>
+    <h2>普通用户面板</h2>
+    <p>功能受限。</p>
+  </template>
+
+  <!-- ==================== 示例 5：复杂条件（结合 computed） ==================== -->
+  <section>
+    <div v-if="isVIP">
+      <span>🌟 VIP 会员专享内容</span>
+      <ul>
+        <li>高级主题</li>
+        <li>专属客服</li>
+      </ul>
+    </div>
+    <div v-else-if="isPremium">
+      <span>💎 高级会员</span>
+    </div>
+    <div v-else>
+      <span>🔓 免费用户</span>
+      <a href="/upgrade">升级会员</a>
+    </div>
+  </section>
+
+  <!-- ==================== 示例 6：嵌套条件 ==================== -->
+  <div v-if="status === 'loading'">
+    <span>⏳ 加载中…</span>
+  </div>
+  <div v-else-if="status === 'error'">
+    <span>❌ 加载失败：{{ errorMessage }}</span>
+    <button @click="retry">重试</button>
+  </div>
+  <div v-else>
+    <div v-if="items.length === 0">
+      <span>📭 暂无数据</span>
+    </div>
+    <div v-else>
+      <ul>
+        <li v-for="(item, index) in items" :key="index">{{ item }}</li>
+      </ul>
+    </div>
+  </div>
+
+  <!-- ==================== 示例 7：可选链操作符 ?. 安全访问 ==================== -->
+  <div v-if="data?.list">
+    <p>data.list 存在且非空，长度为：{{ data.list.length }}</p>
+    <ul>
+      <li v-for="(item, i) in data.list" :key="i">{{ item?.name ?? '未命名' }}</li>
+    </ul>
+  </div>
+  <div v-else-if="data?.list === undefined">
+    <p>data 或 data.list 为 undefined（安全访问避免报错）</p>
+  </div>
+  <div v-else>
+    <p>data.list 存在但为空数组</p>
+  </div>
+
+  <!-- ==================== 示例 8：更深层嵌套的可选链 ==================== -->
+  <article v-if="user?.profile?.address?.city">
+    <h3>{{ user?.name }} 的城市</h3>
+    <p>{{ user?.profile?.address?.city }}，{{ user?.profile?.address?.country }}</p>
+  </article>
+  <article v-else>
+    <h3>{{ user?.name ?? '未知用户' }}</h3>
+    <p>地址信息不完整</p>
+  </article>
+</template>
+
+<script setup>
+import { computed, ref } from 'vue';
+
+// 示例 1
+const showTitle = ref(true);
+
+// 示例 2
+const isLoggedIn = ref(false);
+
+// 示例 3
+const type = ref('B');
+
+// 示例 4
+const hasPermission = ref(true);
+
+// 示例 5：复杂条件
+const userLevel = ref('free');
+const isVIP = computed(() => userLevel.value === 'vip');
+const isPremium = computed(() => userLevel.value === 'premium');
+
+// 示例 6：嵌套条件
+const status = ref('success');
+const errorMessage = ref('');
+const items = ref(['苹果', '香蕉', '橘子']);
+
+function retry() {
+  status.value = 'loading';
+  // 模拟重新请求
+  setTimeout(() => {
+    status.value = 'success';
+    items.value = ['苹果', '香蕉', '橘子', '葡萄'];
+  }, 1000);
+}
+
+// 示例 7：可选链 ?.
+const data = ref(null);
+// 模拟异步获取数据
+setTimeout(() => {
+  data.value = {
+    list: [{ name: '张三' }, { name: null }, { name: '李四' }],
+  };
+}, 2000);
+
+// 示例 8：深层嵌套可选链
+const user = ref({
+  name: 'Alice',
+  profile: {
+    address: {
+      city: '北京',
+      country: '中国',
+    },
+  },
+});
+</script>
+
+<style scoped>
+section {
+  margin: 16px 0;
+  padding: 12px;
+  border: 1px solid #e0e0e0;
+  border-radius: 8px;
+}
+
+button,
+a {
+  margin-left: 8px;
+  padding: 4px 12px;
+  background: #42b883;
+  color: white;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+a {
+  display: inline-block;
+  text-decoration: none;
+}
+
+ul {
+  padding-left: 20px;
+}
+</style>

--- a/packages/compiler-core/src/core/transform/__tests__/with-defaults/expected/output.tsx
+++ b/packages/compiler-core/src/core/transform/__tests__/with-defaults/expected/output.tsx
@@ -1,0 +1,19 @@
+import { useMemo, memo } from 'react';
+interface Props {
+  msg?: string;
+  count?: number;
+  labels: string[];
+}
+export type ICompProps = Props;
+const Input = memo((vrProps: ICompProps) => {
+  /* from withDefaults */
+  const props = useMemo<Readonly<Props>>(() => ({
+    ...vrProps,
+    msg: vrProps.msg ?? 'hello',
+    count: vrProps.count ?? 42,
+    labels: vrProps.labels ?? ['one', 'two']
+  }), [vrProps]);
+  ;
+  return <><div>{props.msg}{props.count}</div><ul>{props.labels.map(value => <li key={value}>{value}</li>)}</ul></>;
+});
+export default Input;

--- a/packages/compiler-core/src/core/transform/__tests__/with-defaults/input.vue
+++ b/packages/compiler-core/src/core/transform/__tests__/with-defaults/input.vue
@@ -1,0 +1,20 @@
+<script setup lang="ts">
+interface Props {
+  msg?: string;
+  count?: number;
+  labels: string[];
+}
+
+const props = withDefaults(defineProps<Props>(), {
+  msg: 'hello',
+  count: 42,
+  labels: () => ['one', 'two'],
+});
+</script>
+
+<template>
+  <div>{{ props.msg }} {{ props.count }}</div>
+  <ul>
+    <li v-for="value in props.labels" :key="value">{{ value }}</li>
+  </ul>
+</template>

--- a/packages/compiler-core/src/core/transform/sfc/script/syntax-processor/index.ts
+++ b/packages/compiler-core/src/core/transform/sfc/script/syntax-processor/index.ts
@@ -6,6 +6,7 @@ import {
   resolveRuntimeImports,
   resolveSfcCssImport,
   resolveVueTypeAsAny,
+  resolveWithDefaults,
 } from './postprocess';
 import {
   resolveCompIProps,
@@ -18,6 +19,7 @@ import {
   resolvePropsIface,
   resolveTemplateSlotIface,
   resolveUseAttrs,
+  resolveWithDefaultsOptions,
 } from './preprocess';
 import {
   resolveAnalysisOnlyAdapter,
@@ -53,6 +55,8 @@ export function processVueSyntax(ast: BabelParseResult, ctx: ICompilationContext
   vueSyntaxProcessor(ast, ctx, {
     preprocess: {
       applyBabel: [
+        // feature: https://github.com/vureact-js/core/issues/63
+        resolveWithDefaultsOptions,
         resolvePropsIface,
         resolveEmitsTopLevelTypes,
         resolveDefineOptions,
@@ -83,6 +87,8 @@ export function processVueSyntax(ast: BabelParseResult, ctx: ICompilationContext
 
     postprocess: {
       applyBabel: [
+        // feature: https://github.com/vureact-js/core/issues/63
+        resolveWithDefaults,
         // 该 resolver 需确保放在所有类型处理之后，移除之前
         resolveVueTypeAsAny,
         resolveRuntimeImports,

--- a/packages/compiler-core/src/core/transform/sfc/script/syntax-processor/postprocess/index.ts
+++ b/packages/compiler-core/src/core/transform/sfc/script/syntax-processor/postprocess/index.ts
@@ -2,3 +2,4 @@ export { resolveASTChunks } from './resolve-ast-chunks';
 export { resolveRuntimeImports } from './resolve-runtime-imports';
 export { resolveSfcCssImport } from './resolve-sfc-css-import';
 export { resolveVueTypeAsAny } from './resolve-vue-type-as-any';
+export { resolveWithDefaults } from './resolve-with-defaults';

--- a/packages/compiler-core/src/core/transform/sfc/script/syntax-processor/postprocess/resolve-with-defaults.ts
+++ b/packages/compiler-core/src/core/transform/sfc/script/syntax-processor/postprocess/resolve-with-defaults.ts
@@ -1,0 +1,166 @@
+import { TraverseOptions } from '@babel/traverse';
+import * as t from '@babel/types';
+import { ICompilationContext, PropsWithDefaults } from '@compiler/context/types';
+import { PACKAGE_NAME } from '@consts/other';
+import { REACT_API_MAP } from '@consts/react-api-map';
+import { recordImport } from '@transform/shared';
+import { createUseMemo } from '../../shared/hook-creator';
+import { WITH_DEFAULTS_PLACEHOLDER } from '../preprocess/resolve-with-defaults';
+
+/**
+ * 处理 withDefaults 宏，根据 preprocess 阶段留下的注释占位符，
+ * 找到对应位置并替换为完整的 `const props = useMemo(...)` 声明。
+ *
+ * 转换结果类似如下：
+ *
+ * - Vue
+ *
+ * ```ts
+ * const props = withDefaults(defineProps<Props>(), {
+ *   msg: 'hello',
+ *   labels: () => ['one', 'two'],
+ * });
+ *```
+ * - → React
+ *
+ * ```tsx
+ * const props = useMemo<Props>(
+ *   () => ({
+ *     msg: $props?.msg ?? 'hello',
+ *     labels: $props?.labels ?? ['one', 'two'],
+ *   }),
+ *   [$props?.msg, $props?.labels],
+ * );
+ * ```
+ */
+export function resolveWithDefaults(ctx: ICompilationContext): TraverseOptions {
+  const { inputType, scriptData } = ctx;
+  const propsWithDefaults = scriptData.propsWithDefaults;
+
+  if (inputType !== 'sfc' || !propsWithDefaults?.values) return {};
+
+  return {
+    Program: {
+      exit(programPath) {
+        const { body } = programPath.node;
+        const placeholderIndex = findPlaceholderIndex(body);
+
+        if (placeholderIndex === -1) return;
+
+        const placeholder = body[placeholderIndex]!;
+        const { varName, values, typeParameters } = propsWithDefaults;
+
+        // 构造完整声明并替换占位符
+        const varDeclaration = createVarDeclaration(
+          varName,
+          values as t.ObjectExpression,
+          typeParameters,
+          ctx.propField,
+          propsWithDefaults,
+        );
+
+        varDeclaration.leadingComments = placeholder.leadingComments;
+
+        body.splice(placeholderIndex, 0, varDeclaration);
+
+        // 记录 useMemo 的导入
+        recordImport(ctx, PACKAGE_NAME.react, REACT_API_MAP.useMemo);
+      },
+    },
+  };
+}
+
+/**
+ * 在 Program.body 中找到 preprocess 阶段留下的占位空语句。
+ */
+function findPlaceholderIndex(body: t.Statement[]): number {
+  return body.findIndex((stmt) => {
+    if (!t.isEmptyStatement(stmt) || !stmt.leadingComments) {
+      return false;
+    }
+
+    return stmt.leadingComments.some(
+      (comment) => comment.type === 'CommentBlock' && comment.value === WITH_DEFAULTS_PLACEHOLDER,
+    );
+  });
+}
+
+/**
+ * 构造完整的 `const <name> = useMemo<TypeParameters>(() => ({...}), [vrProps])` 声明。
+ */
+function createVarDeclaration(
+  varName: string,
+  values: t.ObjectExpression,
+  typeParameters: t.TSTypeParameterInstantiation | null | undefined,
+  propField: string,
+  sourceInfo: PropsWithDefaults,
+): t.VariableDeclaration {
+  const { mergeMembers } = buildMergeLogic(values, propField);
+
+  // 依赖整个组件 props 对象
+  const deps = t.arrayExpression([t.identifier(propField)]);
+  const useMemoCall = createUseMemo(t.objectExpression(mergeMembers), deps);
+
+  // 只有 ts 环境下才可能会有值
+  if (typeParameters) {
+    useMemoCall.typeParameters = typeParameters;
+  }
+
+  // 继承原 withDefaults 调用的位置/注释信息
+  useMemoCall.start = sourceInfo.start;
+  useMemoCall.end = sourceInfo.end;
+  useMemoCall.loc = sourceInfo.loc;
+  useMemoCall.leadingComments = sourceInfo.leadingComments;
+  useMemoCall.innerComments = sourceInfo.innerComments;
+  useMemoCall.trailingComments = sourceInfo.trailingComments;
+
+  const varDeclarator = t.variableDeclarator(t.identifier(varName), useMemoCall);
+  return t.variableDeclaration('const', [varDeclarator]);
+}
+
+/**
+ * 根据默认值对象，生成 useMemo 箭头函数体的成员。
+ *
+ * 输入：{ msg: 'hello', labels: ['one', 'two'] }
+ * 输出：
+ *   [SpreadElement(vrProps),
+ *    ObjectProperty('msg', vrProps.msg ?? 'hello'),
+ *    ObjectProperty('labels', vrProps.labels ?? ['one', 'two'])]
+ */
+function buildMergeLogic(
+  values: t.ObjectExpression,
+  propField: string,
+): {
+  mergeMembers: (t.SpreadElement | t.ObjectMember)[];
+} {
+  const mergeMembers: (t.ObjectMember | t.SpreadElement)[] = [];
+  const propFieldIdent = t.identifier(propField);
+
+  // 1. 展开原始 props：...vrProps
+  mergeMembers.push(t.spreadElement(propFieldIdent));
+
+  // 2. 对每个有默认值的字段生成 vrProps.xx ?? defaultValue
+  for (const defaultProp of values.properties) {
+    if (!t.isObjectProperty(defaultProp)) continue;
+
+    const key = defaultProp.key;
+    if (!t.isIdentifier(key) && !t.isStringLiteral(key)) continue;
+
+    const keyName = t.isIdentifier(key) ? key.name : key.value;
+
+    // vrProps.xx
+    const propAccess = t.memberExpression(propFieldIdent, t.identifier(keyName), false);
+
+    // vrProps.xx ?? defaultValue
+    const logicalExpr = t.logicalExpression('??', propAccess, defaultProp.value as t.Expression);
+
+    mergeMembers.push(
+      t.objectProperty(
+        t.isIdentifier(key) ? t.identifier(keyName) : t.stringLiteral(keyName),
+        logicalExpr,
+      ),
+    );
+  }
+
+  return { mergeMembers };
+}

--- a/packages/compiler-core/src/core/transform/sfc/script/syntax-processor/preprocess/index.ts
+++ b/packages/compiler-core/src/core/transform/sfc/script/syntax-processor/preprocess/index.ts
@@ -13,3 +13,4 @@ export {
   resolveTemplateSlotIface,
 } from './resolve-props-interface/resolve-slot';
 export { resolveUseAttrs } from './resolve-use-attrs';
+export { resolveWithDefaultsOptions } from './resolve-with-defaults';

--- a/packages/compiler-core/src/core/transform/sfc/script/syntax-processor/preprocess/resolve-with-defaults.ts
+++ b/packages/compiler-core/src/core/transform/sfc/script/syntax-processor/preprocess/resolve-with-defaults.ts
@@ -1,0 +1,213 @@
+import { ParseResult } from '@babel/parser';
+import { TraverseOptions } from '@babel/traverse';
+import * as t from '@babel/types';
+import { ICompilationContext } from '@compiler/context/types';
+import { MACRO_API_NAMES } from '@consts/other';
+import { logger } from '@shared/logger';
+import { capitalize } from '@utils/capitalize';
+import { getVariableDeclaratorPath, isCalleeNamed, replaceNode } from '../../shared/babel-utils';
+
+/**
+ * withDefaults 占位标记注释，postprocess 阶段通过此注释定位替换位置。
+ */
+export const WITH_DEFAULTS_PLACEHOLDER = ' from withDefaults ';
+
+/**
+ * 解析 withDefaults 选项。
+ *
+ * 预处理阶段将 withDefaults(...) 调用替换为一个带 `/* from withDefaults *​/` 注释的
+ * 空语句占位符，postprocess 阶段再替换为完整的 `const props = useMemo(...)`。
+ *
+ * 之所以不直接在此阶段生成 useMemo，是因为后续 resolve-props-interface 等处理
+ * 会删除 defineProps 相关的变量声明节点，只有 postprocess 阶段才能确定最终形态。
+ */
+export function resolveWithDefaultsOptions(
+  ctx: ICompilationContext,
+  ast: ParseResult,
+): TraverseOptions {
+  if (ctx.inputType !== 'sfc') return {};
+
+  return {
+    CallExpression(path) {
+      const { node } = path;
+      const { filename, scriptData } = ctx;
+
+      // 1. 校验：是否是 withDefaults 调用
+      if (!isCalleeNamed(node, MACRO_API_NAMES.defaults)) {
+        return;
+      }
+
+      const declaratorPath = getVariableDeclaratorPath(path)!;
+
+      // 2. 校验：必须赋值给变量
+      if (!declaratorPath) {
+        logger.error(
+          `withDefaults() must be assigned to a variable (e.g., const props = withDefaults(...)).`,
+          { file: filename, source: scriptData.source, loc: node.loc },
+        );
+        return;
+      }
+
+      // 3. 获取变量声明名
+      const varName = t.isIdentifier(declaratorPath.node.id)
+        ? declaratorPath.node.id.name
+        : undefined;
+
+      if (!varName) {
+        logger.error('withDefaults() could not determine the variable name from the declaration.', {
+          file: filename,
+          source: scriptData.source,
+          loc: node.loc,
+        });
+        return;
+      }
+
+      // 4. 避免组件 props 参数名与当前变量名冲突
+      ctx.propField = `vr${capitalize(ctx.propField)}`;
+
+      // 5. 校验参数
+      const [defineProps, defaults] = node.arguments;
+
+      if (!node.arguments.length) {
+        logger.error('withDefaults() requires at least one argument (defineProps call).', {
+          file: filename,
+          source: scriptData.source,
+          loc: node.loc,
+        });
+        return;
+      }
+
+      if (!t.isCallExpression(defineProps)) {
+        logger.error(
+          'withDefaults() first argument must be a call to defineProps (e.g., defineProps({...})).',
+          { file: filename, source: scriptData.source, loc: defineProps?.loc },
+        );
+        return;
+      }
+
+      if (defaults && !t.isObjectExpression(defaults)) {
+        logger.error(
+          'withDefaults() second argument must be an object literal (e.g., { msg: "hello" }).',
+          { file: filename, source: scriptData.source, loc: defaults?.loc },
+        );
+        return;
+      }
+
+      // 6. 记录转换所需信息到上下文中
+      recordPropsWithDefaults(ctx, varName, defineProps as t.CallExpression, defaults, node);
+
+      // 7. 在当前声明位置之后插入占位空语句（带特殊注释标记）
+      declaratorPath.parentPath.insertAfter(createPlaceholder(node));
+
+      // 8. 保留 defineProps，移除 withDefaults 包装
+      replaceNode(path, defineProps as t.CallExpression, node);
+    },
+  };
+}
+
+function recordPropsWithDefaults(
+  ctx: ICompilationContext,
+  varName: string,
+  defineProps: t.CallExpression,
+  defaults: t.ObjectExpression | undefined,
+  withDefaults: t.CallExpression,
+) {
+  const { scriptData } = ctx;
+  const { start, end, loc, leadingComments, innerComments, trailingComments } = withDefaults;
+
+  const values = flattenDefaultValues(defaults);
+
+  const getTypeParameters = (): t.TSTypeParameterInstantiation | undefined => {
+    if (!scriptData.lang.startsWith('ts')) {
+      return;
+    }
+
+    const { propsTypes } = scriptData.propsTSIface;
+
+    const typeParameters =
+      defineProps.typeParameters ||
+      (propsTypes.length ? t.tSTypeParameterInstantiation(propsTypes) : undefined);
+
+    if (typeParameters) {
+      return t.tsTypeParameterInstantiation([
+        t.tsTypeReference(t.identifier('Readonly'), typeParameters),
+      ]);
+    }
+  };
+
+  scriptData.propsWithDefaults = {
+    varName,
+    values,
+    start,
+    end,
+    loc,
+    leadingComments,
+    innerComments,
+    trailingComments,
+    typeParameters: getTypeParameters(),
+  };
+}
+
+/**
+ * 展平 withDefaults 第二个参数对象中的函数包装值。
+ *
+ * Vue 中可变类型（数组/对象）的默认值需要用函数包装，如：
+ *   labels: () => ['one', 'two']
+ *
+ * 转换为 React 时需要提取函数返回值，以便后续生成：
+ *   labels: props.labels ?? ['one', 'two']
+ *
+ * 而不可变类型（字符串/数字/布尔）则无需包装，保持不变：
+ *   msg: 'hello'             →  msg: props.msg ?? 'hello'
+ */
+function flattenDefaultValues(expr?: t.ObjectExpression): t.ObjectExpression | undefined {
+  if (!expr) return;
+
+  if (!t.isObjectExpression(expr)) {
+    return expr;
+  }
+
+  const properties = expr.properties.map((prop) => {
+    if (!t.isObjectProperty(prop)) {
+      return prop;
+    }
+
+    const value = prop.value;
+
+    // 如果值是箭头函数或函数表达式，提取其返回值
+    if (t.isArrowFunctionExpression(value) && t.isBlockStatement(value.body)) {
+      const returnStmt = value.body.body.find((stmt): stmt is t.ReturnStatement =>
+        t.isReturnStatement(stmt),
+      );
+      if (returnStmt?.argument) {
+        return t.objectProperty(prop.key, returnStmt.argument, prop.computed);
+      }
+    }
+
+    // 如果值是箭头函数的简写体（无花括号），直接取其表达式
+    if (t.isArrowFunctionExpression(value) && !t.isBlockStatement(value.body)) {
+      return t.objectProperty(prop.key, value.body as t.Expression, prop.computed);
+    }
+
+    return prop;
+  });
+
+  return t.objectExpression(properties);
+}
+
+function createPlaceholder(node: t.CallExpression): t.EmptyStatement {
+  const placeholder = t.emptyStatement();
+
+  const leadingComments: t.Comment[] = [
+    {
+      type: 'CommentBlock',
+      value: WITH_DEFAULTS_PLACEHOLDER,
+      start: node.start!,
+      end: node.end!,
+    },
+  ];
+
+  placeholder.leadingComments = leadingComments;
+
+  return placeholder;
+}

--- a/packages/compiler-core/src/core/transform/sfc/script/syntax-processor/process/resolve-analysis-only-adapter.ts
+++ b/packages/compiler-core/src/core/transform/sfc/script/syntax-processor/process/resolve-analysis-only-adapter.ts
@@ -1,15 +1,20 @@
-import { Binding, NodePath, TraverseOptions } from '@babel/traverse';
+import { NodePath, TraverseOptions } from '@babel/traverse';
 import * as t from '@babel/types';
 import { ICompilationContext } from '@compiler/context/types';
 import { ADAPTER_RULES, AdapterRule } from '@consts/adapters-map';
-import { VUE_PACKAGES } from '@consts/other';
 import { recordImport } from '@transform/shared';
 import { replaceCallName, replaceIdName } from '../../shared/babel-utils';
 import { analyzeDeps } from '../../shared/dependency-analyzer';
+import { isVueApiReference } from './resolve-rename-adapter';
 
 /**
  * 处理“仅依赖分析”的适配规则。
- * 同样只在 Vue 生态 import 来源上生效，避免误命中局部变量。
+ *
+ * 判断逻辑：
+ * 1. 优先检查 binding，仅当标识符来自 Vue 生态 import 时执行替换
+ *    （避免将业务代码中的同名局部变量误判为 Vue API）。
+ * 2. 若 binding 不存在（免 import 场景，如 unplugin-auto-import），
+ *    fallback 到 AUTO_IMPORTED_APIS 白名单匹配。
  */
 export function resolveAnalysisOnlyAdapter(ctx: ICompilationContext): TraverseOptions {
   return {
@@ -77,54 +82,4 @@ function resolveCallNode(
 
   replaceCallName(node, adapter.target);
   recordImport(ctx, adapter.package, adapter.target);
-}
-
-function isVueApiReference(path: NodePath<t.CallExpression | t.Identifier>, apiName: string): boolean {
-  if (path.isIdentifier()) {
-    if (path.parentPath.isCallExpression() && path.parentPath.node.callee === path.node) {
-      return false;
-    }
-
-    if (!path.isReferencedIdentifier()) {
-      return false;
-    }
-  }
-
-  if (path.isCallExpression()) {
-    const callee = path.get('callee');
-    if (!callee.isIdentifier()) return false;
-    return isVueImportBinding(callee.scope.getBinding(apiName));
-  }
-
-  return isVueImportBinding(path.scope.getBinding(apiName));
-}
-
-function isVueImportBinding(binding?: Binding): boolean {
-  if (!binding) return false;
-
-  const bindingPath = binding.path;
-  if (
-    !bindingPath.isImportSpecifier() &&
-    !bindingPath.isImportDefaultSpecifier() &&
-    !bindingPath.isImportNamespaceSpecifier()
-  ) {
-    return false;
-  }
-
-  const parent = bindingPath.parentPath?.node;
-  if (!parent || !t.isImportDeclaration(parent)) {
-    return false;
-  }
-
-  const source = parent.source.value.toLowerCase();
-
-  if (source.startsWith('@vue/')) {
-    return true;
-  }
-
-  if (source === 'vue-router' || source.startsWith('vue-router/')) {
-    return true;
-  }
-
-  return VUE_PACKAGES.some((name) => source === name || source.startsWith(`${name}/`));
 }

--- a/packages/compiler-core/src/core/transform/sfc/script/syntax-processor/process/resolve-rename-adapter.ts
+++ b/packages/compiler-core/src/core/transform/sfc/script/syntax-processor/process/resolve-rename-adapter.ts
@@ -1,9 +1,8 @@
 import { Binding, NodePath, TraverseOptions } from '@babel/traverse';
 import * as t from '@babel/types';
 import { ICompilationContext } from '@compiler/context/types';
-import { ADAPTER_RULES } from '@consts/adapters-map';
+import { ADAPTER_RULES, AUTO_IMPORTED_APIS } from '@consts/adapters-map';
 import { PACKAGE_NAME, VUE_PACKAGES } from '@consts/other';
-import { VUE_API_MAP } from '@consts/vue-api-map';
 import { getReactiveType } from '@shared/reactive-utils';
 import { recordImport } from '@transform/shared';
 import {
@@ -15,8 +14,12 @@ import { setScriptNodeMeta } from '../../shared/metadata-utils';
 
 /**
  * 处理“重命名型”适配规则。
- * 仅当标识符来自 Vue 生态 import 时才执行替换，
- * 避免把业务代码中的同名局部变量误判为 Vue API。
+ *
+ * 判断逻辑：
+ * 1. 优先检查 binding，仅当标识符来自 Vue 生态 import 时执行替换
+ *    （避免将业务代码中的同名局部变量误判为 Vue API）。
+ * 2. 若 binding 不存在（免 import 场景，如 unplugin-auto-import），
+ *    fallback 到 AUTO_IMPORTED_APIS 白名单匹配。
  */
 export function resolveRenameAdapter(ctx: ICompilationContext): TraverseOptions {
   return {
@@ -73,17 +76,10 @@ export function resolveRenameAdapter(ctx: ICompilationContext): TraverseOptions 
   };
 }
 
-function isVueApiReference(
+export function isVueApiReference(
   path: NodePath<t.CallExpression | t.Identifier>,
   apiName: string,
 ): boolean {
-  // 白名单可直接放行
-  const whitelist: string[] = [VUE_API_MAP.defineAsyncComponent];
-
-  if (whitelist.includes(apiName)) {
-    return true;
-  }
-
   if (path.isIdentifier()) {
     // CallExpression 的 callee 由 CallExpression 分支统一处理，避免重复命中。
     if (path.parentPath.isCallExpression() && path.parentPath.node.callee === path.node) {
@@ -96,13 +92,18 @@ function isVueApiReference(
     }
   }
 
-  if (path.isCallExpression()) {
-    const callee = path.get('callee');
-    if (!callee.isIdentifier()) return false;
-    return isVueImportBinding(callee.scope.getBinding(apiName));
+  // 1. 优先检查 binding：有显式 import 且来自 Vue 生态，精确匹配
+  const binding = path.isCallExpression()
+    ? (path.get('callee') as NodePath).scope.getBinding(apiName)
+    : path.scope.getBinding(apiName);
+
+  if (binding) {
+    return isVueImportBinding(binding);
   }
 
-  return isVueImportBinding(path.scope.getBinding(apiName));
+  // fix: https://github.com/vureact-js/core/issues/62
+  // 2. 无 binding（可能免 import 场景），fallback 到 AUTO_IMPORTED_APIS 白名单
+  return AUTO_IMPORTED_APIS.has(apiName);
 }
 
 function isVueImportBinding(binding?: Binding): boolean {


### PR DESCRIPTION
- compiler-core: 
  - 新增 withDefaults 测试用例
  - syntax-processor 注册 withDefaults 处理阶段
  - 修复使用 `unplugin-auto-import` 时，编译器无法识别 Vue API 来源，导致跳过转换
  - 新增无需 Vue API 来源的转换测试用例
  - 更新 v-if 预期输出格式
  - 优化编译流程提示，细分为 3 个阶段：将 `Compiling Vue to React...` 改为 `Compiling components/scripts/styles...`
  - 升级至 v1.10.0 并更新文档

- 更新仓库首页描述文案